### PR TITLE
[WIP] add twitter media viewer

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -56,7 +56,8 @@ android {
 
 def supportLibVer = '24.0.0'
 def t4jVer = '4.0.4'
-def rxVer = '1.1.0'
+def rxVer = '1.1.6'
+def rxAndroidVer = '1.2.1'
 def daggerVer = "2.5"
 def supportTestVer = "0.5"
 def dexmakerVer = '1.4'
@@ -72,7 +73,7 @@ dependencies {
     compile 'com.squareup.picasso:picasso:2.5.2'
     compile 'com.squareup.okhttp3:okhttp:3.4.1'
 
-    compile "io.reactivex:rxandroid:$rxVer"
+    compile "io.reactivex:rxandroid:$rxAndroidVer"
     // Because RxAndroid releases are few and far between, it is recommended you also
     // explicitly depend on RxJava's latest version for bug fixes and new features.
     compile "io.reactivex:rxjava:$rxVer"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -70,7 +70,7 @@ dependencies {
     compile "org.twitter4j:twitter4j-core:$t4jVer"
     compile "org.twitter4j:twitter4j-stream:$t4jVer"
     compile 'com.squareup.picasso:picasso:2.5.2'
-    compile 'com.squareup.okhttp3:okhttp:3.2.0'
+    compile 'com.squareup.okhttp3:okhttp:3.4.1'
 
     compile "io.reactivex:rxandroid:$rxVer"
     // Because RxAndroid releases are few and far between, it is recommended you also

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -35,7 +35,8 @@
                     android:scheme="udonr" />
             </intent-filter>
         </activity>
-        <activity android:name=".MediaViewActivity" />
+        <activity android:name=".MediaViewActivity"
+            android:theme="@style/Theme.AppTheme.TranslucentStatusBar"/>
     </application>
 
 </manifest>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -35,7 +35,7 @@
                     android:scheme="udonr" />
             </intent-filter>
         </activity>
-
+        <activity android:name=".MediaViewActivity" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/freshdigitable/udonroad/MediaContainer.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/MediaContainer.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2016. UdonRoad by Akihito Matsuda (akihito104)
+ */
+
+package com.freshdigitable.udonroad;
+
+import android.content.Context;
+import android.util.AttributeSet;
+import android.widget.LinearLayout;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import twitter4j.ExtendedMediaEntity;
+
+/**
+ * Created by akihit on 2016/07/10.
+ */
+public class MediaContainer extends LinearLayout {
+
+  private int grid;
+
+  public MediaContainer(Context context) {
+    this(context, null);
+  }
+
+  public MediaContainer(Context context, AttributeSet attrs) {
+    this(context, attrs, 0);
+  }
+
+  public MediaContainer(Context context, AttributeSet attrs, int defStyleAttr) {
+    super(context, attrs, defStyleAttr);
+    grid = getResources().getDimensionPixelSize(R.dimen.grid_margin);
+  }
+
+  private int thumbCount;
+  private List<MediaImageView> thumbs = new ArrayList<>(4);
+
+  public void setThumbCount(int count) {
+    this.thumbCount = count;
+    final int size = thumbs.size();
+    if (count <= size) {
+      return;
+    }
+    for (int i=0; i<size-count; i++) {
+      thumbs.add(new MediaImageView(getContext()));
+    }
+  }
+
+  public int getThumbCount() {
+    return thumbCount;
+  }
+
+  private int mediaWidth;
+
+  public int getMediaWidth() {
+    return Math.max(mediaWidth, 0);
+  }
+
+  public void bindMediaEntities(ExtendedMediaEntity[] extendedMediaEntities) {
+    final int mediaCount = Math.min(thumbs.size(), extendedMediaEntities.length);
+    if (mediaCount < 1) {
+      return;
+    }
+    mediaWidth = (getWidth() - grid * (mediaCount - 1)) / mediaCount;
+    setVisibility(VISIBLE);
+    for (int i = 0; i < mediaCount; i++) {
+      thumbs.get(i).setVisibility(VISIBLE);
+    }
+  }
+}

--- a/app/src/main/java/com/freshdigitable/udonroad/MediaImageView.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/MediaImageView.java
@@ -5,6 +5,10 @@
 package com.freshdigitable.udonroad;
 
 import android.content.Context;
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.graphics.drawable.Drawable;
+import android.support.v4.content.ContextCompat;
 import android.support.v7.widget.AppCompatImageView;
 import android.util.AttributeSet;
 
@@ -12,6 +16,8 @@ import android.util.AttributeSet;
  * Created by akihit on 2016/07/10.
  */
 public class MediaImageView extends AppCompatImageView {
+  public static final String TAG = MediaImageView.class.getSimpleName();
+  private Bitmap playIcon;
 
   public MediaImageView(Context context) {
     this(context, null);
@@ -25,5 +31,34 @@ public class MediaImageView extends AppCompatImageView {
     super(context, attrs, defStyleAttr);
     setContentDescription(getResources().getString(R.string.tweet_media_descs));
     setVisibility(GONE);
+
+    final Drawable drawable = ContextCompat.getDrawable(getContext(), R.drawable.ld_play_icon);
+    playIcon = Bitmap.createBitmap(
+        drawable.getIntrinsicWidth(), drawable.getIntrinsicHeight(), Bitmap.Config.ARGB_8888);
+    Canvas canvas = new Canvas(playIcon);
+    drawable.setBounds(0, 0, canvas.getWidth(), canvas.getHeight());
+    drawable.draw(canvas);
+  }
+
+  private boolean showIcon = false;
+
+  public void setShowIcon(boolean showIcon) {
+    this.showIcon = showIcon;
+  }
+
+  @Override
+  protected void onDraw(Canvas canvas) {
+    super.onDraw(canvas);
+    if (showIcon) {
+      int left = (getWidth() - playIcon.getWidth()) / 2;
+      int top = (getHeight() - playIcon.getHeight()) / 2;
+      canvas.drawBitmap(playIcon, left, top, null);
+    }
+  }
+
+  @Override
+  protected void onDetachedFromWindow() {
+    super.onDetachedFromWindow();
+    showIcon = false;
   }
 }

--- a/app/src/main/java/com/freshdigitable/udonroad/MediaImageView.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/MediaImageView.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2016. UdonRoad by Akihito Matsuda (akihito104)
+ */
+
+package com.freshdigitable.udonroad;
+
+import android.content.Context;
+import android.support.v7.widget.AppCompatImageView;
+import android.util.AttributeSet;
+
+/**
+ * Created by akihit on 2016/07/10.
+ */
+public class MediaImageView extends AppCompatImageView {
+
+  private int mediaHeight;
+
+  public MediaImageView(Context context) {
+    this(context, null);
+  }
+
+  public MediaImageView(Context context, AttributeSet attrs) {
+    this(context, attrs, 0);
+  }
+
+  public MediaImageView(Context context, AttributeSet attrs, int defStyleAttr) {
+    super(context, attrs, defStyleAttr);
+    mediaHeight = getResources().getDimensionPixelOffset(R.dimen.tweet_user_icon);
+  }
+
+  public int getMediaHeight() {
+    return mediaHeight;
+  }
+}

--- a/app/src/main/java/com/freshdigitable/udonroad/MediaImageView.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/MediaImageView.java
@@ -13,8 +13,6 @@ import android.util.AttributeSet;
  */
 public class MediaImageView extends AppCompatImageView {
 
-  private int mediaHeight;
-
   public MediaImageView(Context context) {
     this(context, null);
   }
@@ -25,10 +23,7 @@ public class MediaImageView extends AppCompatImageView {
 
   public MediaImageView(Context context, AttributeSet attrs, int defStyleAttr) {
     super(context, attrs, defStyleAttr);
-    mediaHeight = getResources().getDimensionPixelOffset(R.dimen.tweet_user_icon);
-  }
-
-  public int getMediaHeight() {
-    return mediaHeight;
+    setContentDescription(getResources().getString(R.string.tweet_media_descs));
+    setVisibility(GONE);
   }
 }

--- a/app/src/main/java/com/freshdigitable/udonroad/MediaViewActivity.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/MediaViewActivity.java
@@ -304,7 +304,7 @@ public class MediaViewActivity extends AppCompatActivity {
     public void onStart() {
       super.onStart();
       Picasso.with(getContext())
-          .load(mediaEntity.getMediaURLHttps())
+          .load(mediaEntity.getMediaURLHttps() + ":medium")
           .into((ImageView) getView());
     }
 

--- a/app/src/main/java/com/freshdigitable/udonroad/MediaViewActivity.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/MediaViewActivity.java
@@ -353,10 +353,11 @@ public class MediaViewActivity extends AppCompatActivity {
         ExtendedMediaEntity mediaEntity, View.OnClickListener pageClickListener) {
       final MediaFragment fragment;
       final String type = mediaEntity.getType();
-      if ("video".equals(type)) {
-        fragment = new VideoMediaFragment();
-      } else {
+      if ("photo".equals(type)) {
         fragment = new PhotoMediaFragment();
+      } else {
+        // video and animated_gif are distributed as a mp4
+        fragment = new VideoMediaFragment();
       }
       fragment.mediaEntity = mediaEntity;
       fragment.pageClickListener = pageClickListener;

--- a/app/src/main/java/com/freshdigitable/udonroad/MediaViewActivity.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/MediaViewActivity.java
@@ -23,6 +23,7 @@ import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
 import android.view.Gravity;
 import android.view.LayoutInflater;
+import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.WindowManager;
@@ -374,5 +375,39 @@ public class MediaViewActivity extends AppCompatActivity {
       }
       return super.onCreateView(inflater, container, savedInstanceState);
     }
+
+    protected final View.OnTouchListener touchListener = new View.OnTouchListener() {
+      final double LOWER_THRESHOLD = (90 - 10) * Math.PI / 180;
+      final double UPPER_THRESHOLD = (90 + 10) * Math.PI / 180;
+      private MotionEvent old;
+
+      @Override
+      public boolean onTouch(View view, MotionEvent now) {
+        final int action = now.getAction();
+        if (action == MotionEvent.ACTION_DOWN) {
+          old = MotionEvent.obtain(now);
+          return false;
+        }
+        if (action == MotionEvent.ACTION_UP) {
+          try {
+            final float deltaX = now.getX() - old.getX();
+            final float deltaY = now.getY() - old.getY();
+            final double powDist = deltaX * deltaX + deltaY * deltaY;
+            if (powDist < 100) {  // maybe click
+//              Log.d(TAG, "onTouch: click: " + powDist);
+              return false;
+            }
+            final double rad = Math.atan2(deltaY, deltaX);
+            final double absRad = Math.abs(rad);
+            if (absRad > LOWER_THRESHOLD || absRad < UPPER_THRESHOLD) { // maybe swipe to longitude
+              return true;
+            }
+          } finally {
+            old.recycle();
+          }
+        }
+        return false;
+      }
+    };
   }
 }

--- a/app/src/main/java/com/freshdigitable/udonroad/MediaViewActivity.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/MediaViewActivity.java
@@ -6,6 +6,7 @@ package com.freshdigitable.udonroad;
 
 import android.content.Context;
 import android.content.Intent;
+import android.graphics.Color;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
@@ -99,19 +100,25 @@ public class MediaViewActivity extends AppCompatActivity {
     final StatusRealm status = realm.where(StatusRealm.class)
         .equalTo("id", id)
         .findFirst();
-    if (status.getRetweetedStatusId() > 0) {
-      final ReferredStatusRealm rtStatus = realm.where(ReferredStatusRealm.class)
-          .equalTo("id", status.getRetweetedStatusId())
+    if (status != null) {
+      if (status.getRetweetedStatusId() > 0) {
+        final ReferredStatusRealm rtStatus = realm.where(ReferredStatusRealm.class)
+            .equalTo("id", status.getRetweetedStatusId())
+            .findFirst();
+        status.setRetweetedStatus(rtStatus);
+      }
+      if (status.getQuotedStatusId() > 0) {
+        final ReferredStatusRealm qtStatus = realm.where(ReferredStatusRealm.class)
+            .equalTo("id", status.getQuotedStatusId())
+            .findFirst();
+        status.setQuotedStatus(qtStatus);
+      }
+      return status;
+    } else {
+      return realm.where(ReferredStatusRealm.class)
+          .equalTo("id", id)
           .findFirst();
-      status.setRetweetedStatus(rtStatus);
     }
-    if (status.getQuotedStatusId() > 0) {
-      final ReferredStatusRealm qtStatus = realm.where(ReferredStatusRealm.class)
-          .equalTo("id", status.getQuotedStatusId())
-          .findFirst();
-      status.setQuotedStatus(qtStatus);
-    }
-    return status;
   }
 
   @Override
@@ -146,10 +153,6 @@ public class MediaViewActivity extends AppCompatActivity {
   private static class MediaPagerAdapter extends FragmentPagerAdapter {
     private ExtendedMediaEntity[] mediaEntities;
 
-    public MediaPagerAdapter(FragmentManager fm) {
-      this(fm, null);
-    }
-
     public MediaPagerAdapter(FragmentManager fm, ExtendedMediaEntity[] mediaEntities) {
       super(fm);
       this.mediaEntities = mediaEntities;
@@ -179,7 +182,9 @@ public class MediaViewActivity extends AppCompatActivity {
     @Override
     public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container,
                              @Nullable Bundle savedInstanceState) {
-      return new ImageView(getContext());
+      final ImageView imageView = new ImageView(getContext());
+      imageView.setBackgroundColor(Color.BLACK);
+      return imageView;
     }
 
     @Override
@@ -187,7 +192,6 @@ public class MediaViewActivity extends AppCompatActivity {
       super.onStart();
       Picasso.with(getContext())
           .load(mediaEntity.getMediaURLHttps())
-          .fit()
           .into((ImageView) getView());
     }
 

--- a/app/src/main/java/com/freshdigitable/udonroad/MediaViewActivity.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/MediaViewActivity.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) 2016. UdonRoad by Akihito Matsuda (akihito104)
+ */
+
+package com.freshdigitable.udonroad;
+
+import android.content.Context;
+import android.content.Intent;
+import android.os.Build;
+import android.os.Bundle;
+import android.os.Handler;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentManager;
+import android.support.v4.app.FragmentPagerAdapter;
+import android.support.v4.view.ViewPager;
+import android.support.v7.app.AppCompatActivity;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ImageView;
+
+import com.freshdigitable.udonroad.realmdata.ReferredStatusRealm;
+import com.freshdigitable.udonroad.realmdata.StatusRealm;
+import com.squareup.picasso.Picasso;
+
+import io.realm.Realm;
+import io.realm.RealmConfiguration;
+import twitter4j.ExtendedMediaEntity;
+import twitter4j.Status;
+
+/**
+ * Created by akihit on 2016/07/12.
+ */
+public class MediaViewActivity extends AppCompatActivity {
+  private static final String CREATE_STATUS = "status";
+  private static final String CREATE_START = "start";
+  private final ViewGroup.LayoutParams layoutParams = new ViewGroup.LayoutParams(
+      ViewGroup.LayoutParams.MATCH_PARENT,
+      ViewGroup.LayoutParams.MATCH_PARENT);
+  private Realm realm;
+  private ViewPager viewPager;
+
+  public static Intent create(@NonNull Context context, @NonNull Status status) {
+    return create(context, status, 0);
+  }
+
+  public static Intent create(@NonNull Context context, @NonNull Status status, int startPage) {
+    if (status.getExtendedMediaEntities().length < startPage + 1) {
+      throw new IllegalArgumentException(
+          "startPage number exceeded ExtendedMediaEntities length: " + startPage);
+    }
+
+    Intent intent = new Intent(context, MediaViewActivity.class);
+    intent.putExtra(CREATE_STATUS, status.getId());
+    intent.putExtra(CREATE_START, startPage);
+    return intent;
+  }
+
+  @Override
+  protected void onCreate(@Nullable Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+
+    viewPager = new ViewPager(this);
+    viewPager.setId(R.id.user_pager);
+    setContentView(viewPager, layoutParams);
+
+    showSystemUI();
+  }
+
+  private void showSystemUI() {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
+      getWindow().getDecorView().setSystemUiVisibility(
+          View.SYSTEM_UI_FLAG_LAYOUT_STABLE
+              | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
+              | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+      );
+    }
+  }
+
+  private void hideSystemUI() {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+      getWindow().getDecorView().setSystemUiVisibility(
+          View.SYSTEM_UI_FLAG_LAYOUT_STABLE
+              | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
+              | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+              | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION // hide nav bar
+              | View.SYSTEM_UI_FLAG_FULLSCREEN // hide status bar
+              | View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY);
+    } else {
+      getWindow().getDecorView().setSystemUiVisibility(
+          View.SYSTEM_UI_FLAG_HIDE_NAVIGATION // hide nav bar
+      );
+    }
+  }
+
+  private Status findStatus(long id) {
+    final StatusRealm status = realm.where(StatusRealm.class)
+        .equalTo("id", id)
+        .findFirst();
+    if (status.getRetweetedStatusId() > 0) {
+      final ReferredStatusRealm rtStatus = realm.where(ReferredStatusRealm.class)
+          .equalTo("id", status.getRetweetedStatusId())
+          .findFirst();
+      status.setRetweetedStatus(rtStatus);
+    }
+    if (status.getQuotedStatusId() > 0) {
+      final ReferredStatusRealm qtStatus = realm.where(ReferredStatusRealm.class)
+          .equalTo("id", status.getQuotedStatusId())
+          .findFirst();
+      status.setQuotedStatus(qtStatus);
+    }
+    return status;
+  }
+
+  @Override
+  protected void onStart() {
+    super.onStart();
+    realm = Realm.getInstance(
+        new RealmConfiguration.Builder(getApplicationContext())
+            .name("home").build());
+
+    final Intent intent = getIntent();
+    final long statusId = intent.getLongExtra(CREATE_STATUS, -1);
+    final Status status = findStatus(statusId);
+    final int startPage = intent.getIntExtra(CREATE_START, 0);
+    viewPager.setAdapter(new MediaPagerAdapter(getSupportFragmentManager(),
+        status.getExtendedMediaEntities()));
+
+    final Handler handler = new Handler();
+    handler.postDelayed(new Runnable() {
+      @Override
+      public void run() {
+        hideSystemUI();
+      }
+    }, 350);
+  }
+
+  @Override
+  protected void onStop() {
+    realm.close();
+    super.onStop();
+  }
+
+  private static class MediaPagerAdapter extends FragmentPagerAdapter {
+    private ExtendedMediaEntity[] mediaEntities;
+
+    public MediaPagerAdapter(FragmentManager fm) {
+      this(fm, null);
+    }
+
+    public MediaPagerAdapter(FragmentManager fm, ExtendedMediaEntity[] mediaEntities) {
+      super(fm);
+      this.mediaEntities = mediaEntities;
+    }
+
+    @Override
+    public Fragment getItem(int position) {
+      return MediaFragment.create(mediaEntities[position]);
+    }
+
+    @Override
+    public int getCount() {
+      return mediaEntities.length;
+    }
+  }
+
+  public static class MediaFragment extends Fragment {
+    private static Fragment create(ExtendedMediaEntity mediaEntity) {
+      final MediaFragment fragment = new MediaFragment();
+      fragment.mediaEntity = mediaEntity;
+      return fragment;
+    }
+
+    private ExtendedMediaEntity mediaEntity;
+
+    @Nullable
+    @Override
+    public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container,
+                             @Nullable Bundle savedInstanceState) {
+      return new ImageView(getContext());
+    }
+
+    @Override
+    public void onStart() {
+      super.onStart();
+      Picasso.with(getContext())
+          .load(mediaEntity.getMediaURLHttps())
+          .fit()
+          .into((ImageView) getView());
+    }
+
+    @Override
+    public void onStop() {
+      Picasso.with(getContext()).cancelRequest((ImageView) getView());
+      super.onStop();
+    }
+  }
+}

--- a/app/src/main/java/com/freshdigitable/udonroad/PhotoMediaFragment.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/PhotoMediaFragment.java
@@ -17,12 +17,17 @@ import com.squareup.picasso.Picasso;
  * Created by akihit on 2016/07/17.
  */
 public class PhotoMediaFragment extends MediaViewActivity.MediaFragment {
+  public static final String TAG = PhotoMediaFragment.class.getSimpleName();
+  private ImageView imageView;
+
   @Nullable
   @Override
   public View onCreateView(LayoutInflater inflater,
                            @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
     super.onCreateView(inflater, container, savedInstanceState);
-    return new ImageView(getContext());
+    imageView = new ImageView(getContext());
+    imageView.setOnClickListener(pageClickListener);
+    return imageView;
   }
 
   @Override
@@ -36,6 +41,7 @@ public class PhotoMediaFragment extends MediaViewActivity.MediaFragment {
   @Override
   public void onStop() {
     Picasso.with(getContext()).cancelRequest((ImageView) getView());
+    imageView.setOnClickListener(null);
     super.onStop();
   }
 }

--- a/app/src/main/java/com/freshdigitable/udonroad/PhotoMediaFragment.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/PhotoMediaFragment.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2016. UdonRoad by Akihito Matsuda (akihito104)
+ */
+
+package com.freshdigitable.udonroad;
+
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ImageView;
+
+import com.squareup.picasso.Picasso;
+
+/**
+ * Created by akihit on 2016/07/17.
+ */
+public class PhotoMediaFragment extends MediaViewActivity.MediaFragment {
+  @Nullable
+  @Override
+  public View onCreateView(LayoutInflater inflater,
+                           @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
+    super.onCreateView(inflater, container, savedInstanceState);
+    return new ImageView(getContext());
+  }
+
+  @Override
+  public void onStart() {
+    super.onStart();
+    Picasso.with(getContext())
+        .load(mediaEntity.getMediaURLHttps() + ":medium")
+        .into((ImageView) getView());
+  }
+
+  @Override
+  public void onStop() {
+    Picasso.with(getContext()).cancelRequest((ImageView) getView());
+    super.onStop();
+  }
+}

--- a/app/src/main/java/com/freshdigitable/udonroad/PhotoMediaFragment.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/PhotoMediaFragment.java
@@ -26,13 +26,14 @@ public class PhotoMediaFragment extends MediaViewActivity.MediaFragment {
                            @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
     super.onCreateView(inflater, container, savedInstanceState);
     imageView = new ImageView(getContext());
-    imageView.setOnClickListener(pageClickListener);
     return imageView;
   }
 
   @Override
   public void onStart() {
     super.onStart();
+    imageView.setOnClickListener(super.pageClickListener);
+    imageView.setOnTouchListener(super.touchListener);
     Picasso.with(getContext())
         .load(mediaEntity.getMediaURLHttps() + ":medium")
         .into((ImageView) getView());
@@ -42,6 +43,7 @@ public class PhotoMediaFragment extends MediaViewActivity.MediaFragment {
   public void onStop() {
     Picasso.with(getContext()).cancelRequest((ImageView) getView());
     imageView.setOnClickListener(null);
+    imageView.setOnTouchListener(null);
     super.onStop();
   }
 }

--- a/app/src/main/java/com/freshdigitable/udonroad/QuotedStatusView.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/QuotedStatusView.java
@@ -41,13 +41,7 @@ public class QuotedStatusView extends StatusViewBase {
     rtCount = (TextView) v.findViewById(R.id.q_rtcount);
     favIcon = (ImageView) v.findViewById(R.id.q_fav_icon);
     favCount = (TextView) v.findViewById(R.id.q_favcount);
-    mediaGroup = v.findViewById(R.id.q_image_group);
-    mediaImages = new ImageView[]{
-        (ImageView) v.findViewById(R.id.q_image_1),
-        (ImageView) v.findViewById(R.id.q_image_2),
-        (ImageView) v.findViewById(R.id.q_image_3),
-        (ImageView) v.findViewById(R.id.q_image_4)
-    };
+    mediaContainer = (MediaContainer) v.findViewById(R.id.q_image_group);
   }
 
   @Override

--- a/app/src/main/java/com/freshdigitable/udonroad/SnackBarUtil.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/SnackBarUtil.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2016. UdonRoad by Akihito Matsuda (akihito104)
+ */
+
+package com.freshdigitable.udonroad;
+
+import android.support.annotation.NonNull;
+import android.support.design.widget.Snackbar;
+import android.view.View;
+
+import rx.functions.Action0;
+
+/**
+ * Created by akihit on 2016/07/14.
+ */
+public class SnackbarUtil {
+
+  public static Snackbar create(@NonNull final View root, final String text) {
+    return create(root, text, Snackbar.LENGTH_SHORT);
+  }
+
+  public static Snackbar create(@NonNull View root, String text, int length) {
+    return Snackbar.make(root, text, length);
+  }
+
+  public static void show(@NonNull final View root, final String text) {
+    create(root, text).show();
+  }
+
+  public static Action0 action(@NonNull final View root, final String text) {
+    return new Action0() {
+      @Override
+      public void call() {
+        show(root, text);
+      }
+    };
+  }
+
+  private SnackbarUtil() {
+  }
+}

--- a/app/src/main/java/com/freshdigitable/udonroad/StatusView.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/StatusView.java
@@ -46,13 +46,7 @@ public class StatusView extends StatusViewBase {
     rtUserContainer = (LinearLayout) v.findViewById(R.id.tl_rt_user_container);
     rtUser = (TextView) v.findViewById(R.id.tl_rt_user);
     rtUserIcon = (ImageView) v.findViewById(R.id.tl_rt_user_icon);
-    mediaGroup = v.findViewById(R.id.tl_image_group);
-    mediaImages = new ImageView[]{
-        (ImageView) v.findViewById(R.id.tl_image_1),
-        (ImageView) v.findViewById(R.id.tl_image_2),
-        (ImageView) v.findViewById(R.id.tl_image_3),
-        (ImageView) v.findViewById(R.id.tl_image_4)
-    };
+    mediaContainer = (MediaContainer) v.findViewById(R.id.tl_image_group);
     quotedStatus = (QuotedStatusView) v.findViewById(R.id.tl_quoted);
   }
 

--- a/app/src/main/java/com/freshdigitable/udonroad/StatusViewBase.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/StatusViewBase.java
@@ -13,15 +13,12 @@ import android.support.v4.content.ContextCompat;
 import android.support.v4.graphics.drawable.DrawableCompat;
 import android.text.Html;
 import android.util.AttributeSet;
-import android.view.View;
-import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
 
 import java.util.Date;
 
-import twitter4j.ExtendedMediaEntity;
 import twitter4j.Status;
 import twitter4j.User;
 import twitter4j.util.TimeSpanConverter;
@@ -39,8 +36,7 @@ public abstract class StatusViewBase extends RelativeLayout {
   protected TextView rtCount;
   protected ImageView favIcon;
   protected TextView favCount;
-  protected View mediaGroup;
-  protected ImageView[] mediaImages;
+  protected MediaContainer mediaContainer;
   protected final int grid;
   protected static final TimeSpanConverter timeSpanConv = new TimeSpanConverter();
 
@@ -138,11 +134,10 @@ public abstract class StatusViewBase extends RelativeLayout {
     }
   }
 
-  protected int mediaWidth;
   protected final int mediaHeight;
 
   public int getMediaWidth() {
-    return Math.max(mediaWidth, 0);
+    return Math.max(mediaContainer.getThumbWidth(), 0);
   }
 
   public int getMediaHeight() {
@@ -150,15 +145,7 @@ public abstract class StatusViewBase extends RelativeLayout {
   }
 
   protected void bindMediaEntities(Status status) {
-    final ExtendedMediaEntity[] extendedMediaEntities = status.getExtendedMediaEntities();
-    final int mediaCount = Math.min(mediaImages.length, extendedMediaEntities.length);
-    if (mediaCount > 0) {
-      mediaWidth = (mediaGroup.getWidth() - grid * (mediaCount - 1)) / mediaCount;
-      mediaGroup.setVisibility(VISIBLE);
-      for (int i = 0; i < mediaCount; i++) {
-        mediaImages[i].setVisibility(VISIBLE);
-      }
-    }
+    mediaContainer.bindMediaEntities(status.getExtendedMediaEntities());
   }
 
   protected Status getBindingStatus(Status status) {
@@ -203,14 +190,7 @@ public abstract class StatusViewBase extends RelativeLayout {
     setOnClickListener(null);
     setUserIconClickListener(null);
 
-    for (ImageView mi : mediaImages) {
-      mi.setImageDrawable(null);
-      final ViewGroup.LayoutParams layoutParams = mi.getLayoutParams();
-      layoutParams.width = 0;
-      mi.setLayoutParams(layoutParams);
-      mi.setVisibility(GONE);
-    }
-    mediaGroup.setVisibility(GONE);
+    mediaContainer.reset();
   }
 
   public void setUserIconClickListener(OnClickListener userIconClickListener) {
@@ -226,9 +206,9 @@ public abstract class StatusViewBase extends RelativeLayout {
     return icon;
   }
 
-  public ImageView[] getMediaImages() {
-    return mediaImages;
-  }
-
   protected abstract String parseText(Status status);
+
+  public MediaContainer getMediaContainer() {
+    return mediaContainer;
+  }
 }

--- a/app/src/main/java/com/freshdigitable/udonroad/StatusViewBase.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/StatusViewBase.java
@@ -54,7 +54,6 @@ public abstract class StatusViewBase extends RelativeLayout {
     grid = getResources().getDimensionPixelSize(R.dimen.grid_margin);
     setPadding(grid, grid, grid, grid);
     setBackgroundColor(Color.TRANSPARENT);
-    mediaHeight = getResources().getDimensionPixelOffset(R.dimen.tweet_user_icon);
   }
 
   @CallSuper
@@ -132,16 +131,6 @@ public abstract class StatusViewBase extends RelativeLayout {
           : R.color.colorTwitterActionNormal);
       this.favCount.setText(String.valueOf(favCount));
     }
-  }
-
-  protected final int mediaHeight;
-
-  public int getMediaWidth() {
-    return Math.max(mediaContainer.getThumbWidth(), 0);
-  }
-
-  public int getMediaHeight() {
-    return mediaHeight;
   }
 
   protected void bindMediaEntities(Status status) {

--- a/app/src/main/java/com/freshdigitable/udonroad/StatusViewBase.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/StatusViewBase.java
@@ -142,9 +142,7 @@ public abstract class StatusViewBase extends RelativeLayout {
   protected final int mediaHeight;
 
   public int getMediaWidth() {
-    return mediaWidth > 0
-        ? mediaWidth
-        : 0;
+    return Math.max(mediaWidth, 0);
   }
 
   public int getMediaHeight() {
@@ -153,8 +151,7 @@ public abstract class StatusViewBase extends RelativeLayout {
 
   protected void bindMediaEntities(Status status) {
     final ExtendedMediaEntity[] extendedMediaEntities = status.getExtendedMediaEntities();
-    final int mediaCount = extendedMediaEntities.length > mediaImages.length
-        ? mediaImages.length : extendedMediaEntities.length;
+    final int mediaCount = Math.min(mediaImages.length, extendedMediaEntities.length);
     if (mediaCount > 0) {
       mediaWidth = (mediaGroup.getWidth() - grid * (mediaCount - 1)) / mediaCount;
       mediaGroup.setVisibility(VISIBLE);

--- a/app/src/main/java/com/freshdigitable/udonroad/TimelineAdapter.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/TimelineAdapter.java
@@ -116,6 +116,10 @@ public class TimelineAdapter extends RecyclerView.Adapter<TimelineAdapter.ViewHo
     for (int i = 0; i < mediaCount; i++) {
       final MediaImageView mediaView = (MediaImageView) mediaContainer.getChildAt(i);
       final int num = i;
+
+      final String type = extendedMediaEntities[i].getType();
+      mediaView.setShowIcon("video".equals(type) || "animated_gif".equals(type));
+
       mediaView.setOnClickListener(new View.OnClickListener() {
         @Override
         public void onClick(View view) {

--- a/app/src/main/java/com/freshdigitable/udonroad/TimelineAdapter.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/TimelineAdapter.java
@@ -92,10 +92,7 @@ public class TimelineAdapter extends RecyclerView.Adapter<TimelineAdapter.ViewHo
       setSelectedBackground(holder.itemView);
       selectedStatusHolder = new SelectedStatus(holder);
     }
-
-    loadMediaView(status,
-        itemView.getMediaHeight(), itemView.getMediaWidth(),
-        itemView.getMediaContainer());
+    loadMediaView(status, itemView.getMediaContainer());
 
     final Status quotedStatus = status.isRetweet()
         ? status.getRetweetedStatus().getQuotedStatus()
@@ -106,32 +103,29 @@ public class TimelineAdapter extends RecyclerView.Adapter<TimelineAdapter.ViewHo
           .load(quotedStatus.getUser().getMiniProfileImageURLHttps())
           .fit()
           .into(quotedStatusView.getIcon());
-      loadMediaView(quotedStatus,
-          quotedStatusView.getMediaHeight(), quotedStatusView.getMediaWidth(),
-          quotedStatusView.getMediaContainer());
+      loadMediaView(quotedStatus, quotedStatusView.getMediaContainer());
     }
   }
 
-  private void loadMediaView(final Status status,
-                             int mediaHeight, int mediaWidth,
-                             MediaContainer mediaContainer) {
+  private void loadMediaView(final Status status, MediaContainer mediaContainer) {
     ExtendedMediaEntity[] extendedMediaEntities = status.getExtendedMediaEntities();
     final int mediaCount = mediaContainer.getThumbCount();
     for (int i = 0; i < mediaCount; i++) {
       final View mediaView = mediaContainer.getChildAt(i);
+      final int num = i;
       mediaView.setOnClickListener(new View.OnClickListener() {
         @Override
         public void onClick(View view) {
-          final Intent intent = MediaViewActivity.create(view.getContext(), status);
+          final Intent intent = MediaViewActivity.create(view.getContext(), status, num);
           view.getContext().startActivity(intent);
         }
       });
       final RequestCreator rc = Picasso.with(mediaContainer.getContext())
           .load(extendedMediaEntities[i].getMediaURLHttps() + ":thumb");
-      if (mediaHeight == 0 || mediaWidth == 0) {
+      if (mediaContainer.getHeight() == 0 || mediaContainer.getThumbWidth() == 0) {
         rc.fit();
       } else {
-        rc.resize(mediaWidth, mediaHeight);
+        rc.resize(mediaContainer.getThumbWidth(), mediaContainer.getHeight());
       }
       rc.centerCrop()
           .into((ImageView) mediaView);

--- a/app/src/main/java/com/freshdigitable/udonroad/TimelineAdapter.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/TimelineAdapter.java
@@ -114,7 +114,7 @@ public class TimelineAdapter extends RecyclerView.Adapter<TimelineAdapter.ViewHo
     }
     final int mediaCount = mediaContainer.getThumbCount();
     for (int i = 0; i < mediaCount; i++) {
-      final View mediaView = mediaContainer.getChildAt(i);
+      final MediaImageView mediaView = (MediaImageView) mediaContainer.getChildAt(i);
       final int num = i;
       mediaView.setOnClickListener(new View.OnClickListener() {
         @Override
@@ -131,7 +131,7 @@ public class TimelineAdapter extends RecyclerView.Adapter<TimelineAdapter.ViewHo
         rc.resize(mediaContainer.getThumbWidth(), mediaContainer.getHeight());
       }
       rc.centerCrop()
-          .into((ImageView) mediaView);
+          .into(mediaView);
     }
   }
 

--- a/app/src/main/java/com/freshdigitable/udonroad/TimelineAdapter.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/TimelineAdapter.java
@@ -1,5 +1,6 @@
 package com.freshdigitable.udonroad;
 
+import android.content.Intent;
 import android.graphics.Color;
 import android.support.v4.content.ContextCompat;
 import android.support.v7.widget.RecyclerView;
@@ -92,7 +93,7 @@ public class TimelineAdapter extends RecyclerView.Adapter<TimelineAdapter.ViewHo
       selectedStatusHolder = new SelectedStatus(holder);
     }
 
-    loadMediaView(status.getExtendedMediaEntities(),
+    loadMediaView(status,
         itemView.getMediaHeight(), itemView.getMediaWidth(),
         itemView.getMediaContainer());
 
@@ -105,17 +106,26 @@ public class TimelineAdapter extends RecyclerView.Adapter<TimelineAdapter.ViewHo
           .load(quotedStatus.getUser().getMiniProfileImageURLHttps())
           .fit()
           .into(quotedStatusView.getIcon());
-      loadMediaView(quotedStatus.getExtendedMediaEntities(),
+      loadMediaView(quotedStatus,
           quotedStatusView.getMediaHeight(), quotedStatusView.getMediaWidth(),
           quotedStatusView.getMediaContainer());
     }
   }
 
-  private void loadMediaView(ExtendedMediaEntity[] extendedMediaEntities,
-                               int mediaHeight, int mediaWidth,
-                               MediaContainer mediaContainer) {
+  private void loadMediaView(final Status status,
+                             int mediaHeight, int mediaWidth,
+                             MediaContainer mediaContainer) {
+    ExtendedMediaEntity[] extendedMediaEntities = status.getExtendedMediaEntities();
     final int mediaCount = mediaContainer.getThumbCount();
     for (int i = 0; i < mediaCount; i++) {
+      final View mediaView = mediaContainer.getChildAt(i);
+      mediaView.setOnClickListener(new View.OnClickListener() {
+        @Override
+        public void onClick(View view) {
+          final Intent intent = MediaViewActivity.create(view.getContext(), status);
+          view.getContext().startActivity(intent);
+        }
+      });
       final RequestCreator rc = Picasso.with(mediaContainer.getContext())
           .load(extendedMediaEntities[i].getMediaURLHttps() + ":thumb");
       if (mediaHeight == 0 || mediaWidth == 0) {
@@ -124,7 +134,7 @@ public class TimelineAdapter extends RecyclerView.Adapter<TimelineAdapter.ViewHo
         rc.resize(mediaWidth, mediaHeight);
       }
       rc.centerCrop()
-          .into((ImageView) mediaContainer.getChildAt(i));
+          .into((ImageView) mediaView);
     }
   }
 
@@ -165,6 +175,7 @@ public class TimelineAdapter extends RecyclerView.Adapter<TimelineAdapter.ViewHo
         && mediaContainer.getChildAt(0).getVisibility() == View.VISIBLE) {
       for (int i = 0; i < mediaContainer.getThumbCount(); i++) {
         final ImageView iv = (ImageView) mediaContainer.getChildAt(i);
+        iv.setOnClickListener(null);
         Picasso.with(v.getContext()).cancelRequest(iv);
       }
     }

--- a/app/src/main/java/com/freshdigitable/udonroad/TimelineAdapter.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/TimelineAdapter.java
@@ -118,8 +118,7 @@ public class TimelineAdapter extends RecyclerView.Adapter<TimelineAdapter.ViewHo
   private void loadMediaView(ExtendedMediaEntity[] extendedMediaEntities,
                                int mediaHeight, int mediaWidth,
                                ImageView[] mediaImages) {
-    final int mediaCount = extendedMediaEntities.length > mediaImages.length
-        ? mediaImages.length : extendedMediaEntities.length;
+    final int mediaCount = Math.min(extendedMediaEntities.length, mediaImages.length);
     for (int i = 0; i < mediaCount; i++) {
       final RequestCreator rc = Picasso.with(mediaImages[i].getContext())
           .load(extendedMediaEntities[i].getMediaURLHttps() + ":thumb");

--- a/app/src/main/java/com/freshdigitable/udonroad/TimelineAdapter.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/TimelineAdapter.java
@@ -109,6 +109,9 @@ public class TimelineAdapter extends RecyclerView.Adapter<TimelineAdapter.ViewHo
 
   private void loadMediaView(final Status status, MediaContainer mediaContainer) {
     ExtendedMediaEntity[] extendedMediaEntities = status.getExtendedMediaEntities();
+    if (extendedMediaEntities.length < 1) {
+      return;
+    }
     final int mediaCount = mediaContainer.getThumbCount();
     for (int i = 0; i < mediaCount; i++) {
       final View mediaView = mediaContainer.getChildAt(i);

--- a/app/src/main/java/com/freshdigitable/udonroad/TimelineAnimator.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/TimelineAnimator.java
@@ -587,7 +587,8 @@ public class TimelineAnimator extends SimpleItemAnimator {
   }
 
   private void cancelAll(List<ViewHolder> viewHolders) {
-    for (ViewHolder vh : viewHolders) {
+    for (int i = viewHolders.size() - 1; i >= 0; i--) {
+      final ViewHolder vh = viewHolders.get(i);
       ViewCompat.animate(vh.itemView).cancel();
     }
     viewHolders.clear();

--- a/app/src/main/java/com/freshdigitable/udonroad/TimelineFragment.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/TimelineFragment.java
@@ -6,7 +6,6 @@ package com.freshdigitable.udonroad;
 import android.databinding.DataBindingUtil;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
-import android.support.design.widget.Snackbar;
 import android.support.v4.app.Fragment;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
@@ -26,7 +25,6 @@ import java.util.List;
 import javax.inject.Inject;
 
 import rx.android.schedulers.AndroidSchedulers;
-import rx.functions.Action0;
 import rx.functions.Action1;
 import twitter4j.Paging;
 import twitter4j.Status;
@@ -279,6 +277,7 @@ public class TimelineFragment extends Fragment {
 
   private void fetchRetweet(final long tweetId) {
     final TimelineAdapter adapter = getTimelineAdapter();
+    final View rootView = binding.getRoot();
     twitterApi.retweetStatus(tweetId)
         .observeOn(AndroidSchedulers.mainThread())
         .subscribe(
@@ -291,19 +290,15 @@ public class TimelineFragment extends Fragment {
             new Action1<Throwable>() {
               @Override
               public void call(Throwable throwable) {
-                showSnackbar("failed to retweet...");
+                SnackbarUtil.show(rootView, "failed to retweet...");
               }
             },
-            new Action0() {
-              @Override
-              public void call() {
-                showSnackbar("success to retweet");
-              }
-            });
+            SnackbarUtil.action(rootView, "success to retweet"));
   }
 
   private void fetchFavorite(final long tweetId) {
     final TimelineAdapter adapter = getTimelineAdapter();
+    final View rootView = binding.getRoot();
     twitterApi.createFavorite(tweetId)
         .observeOn(AndroidSchedulers.mainThread())
         .subscribe(
@@ -319,20 +314,15 @@ public class TimelineFragment extends Fragment {
                 if (e instanceof TwitterException) {
                   final int statusCode = ((TwitterException) e).getStatusCode();
                   if (statusCode == 403) {
-                    showSnackbar("already faved");
+                    SnackbarUtil.show(rootView, "already faved");
                     return;
                   }
                 }
                 Log.e(TAG, "error: ", e);
-                showSnackbar("failed to create fav...");
+                SnackbarUtil.show(rootView, "failed to create fav...");
               }
             },
-            new Action0() {
-              @Override
-              public void call() {
-                showSnackbar("success to create fav.");
-              }
-            });
+            SnackbarUtil.action(rootView, "success to create fav."));
   }
 
   protected void fetchTweet() {
@@ -370,11 +360,6 @@ public class TimelineFragment extends Fragment {
                 Log.e(TAG, "home timeline is not downloaded.", e);
               }
             });
-  }
-
-  private void showSnackbar(String text) {
-    Snackbar.make(binding.getRoot(), text, Snackbar.LENGTH_SHORT)
-        .show();
   }
 
   protected TwitterApi getTwitterApi() {

--- a/app/src/main/java/com/freshdigitable/udonroad/TwitterApiComponent.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/TwitterApiComponent.java
@@ -18,6 +18,8 @@ public interface TwitterApiComponent {
 
   void inject(MainActivity activity);
 
+  void inject(MediaViewActivity mediaViewActivity);
+
   void inject(UserStreamUtil userStreamUtil);
 
   void inject(TimelineFragment timelineFragment);

--- a/app/src/main/java/com/freshdigitable/udonroad/VideoMediaFragment.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/VideoMediaFragment.java
@@ -19,7 +19,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 
-import twitter4j.ExtendedMediaEntity;
+import twitter4j.ExtendedMediaEntity.Variant;
 
 /**
  * Created by akihit on 2016/07/17.
@@ -91,26 +91,26 @@ public class VideoMediaFragment extends MediaViewActivity.MediaFragment {
   }
 
   private String selectVideo() {
-    final List<ExtendedMediaEntity.Variant> playableMedia = findPlayableMedia();
+    final List<Variant> playableMedia = findPlayableMedia();
     if (playableMedia.size() == 0) {
       return null;
     } else if (playableMedia.size() == 1) {
       return playableMedia.get(0).getUrl();
     }
 
-    Collections.sort(playableMedia, new Comparator<ExtendedMediaEntity.Variant>() {
+    Collections.sort(playableMedia, new Comparator<Variant>() {
       @Override
-      public int compare(ExtendedMediaEntity.Variant l, ExtendedMediaEntity.Variant r) {
+      public int compare(Variant l, Variant r) {
         return l.getBitrate() - r.getBitrate();
       }
     });
     return playableMedia.get(1).getUrl();
   }
 
-  private List<ExtendedMediaEntity.Variant> findPlayableMedia() {
-    final ExtendedMediaEntity.Variant[] videoVariants = mediaEntity.getVideoVariants();
-    List<ExtendedMediaEntity.Variant> res = new ArrayList<>(videoVariants.length);
-    for (ExtendedMediaEntity.Variant v : videoVariants) {
+  private List<Variant> findPlayableMedia() {
+    final Variant[] videoVariants = mediaEntity.getVideoVariants();
+    List<Variant> res = new ArrayList<>(videoVariants.length);
+    for (Variant v : videoVariants) {
       if (v.getContentType().equals("video/mp4")) {
         res.add(v);
       }

--- a/app/src/main/java/com/freshdigitable/udonroad/VideoMediaFragment.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/VideoMediaFragment.java
@@ -28,13 +28,29 @@ public class VideoMediaFragment extends MediaViewActivity.MediaFragment {
   @SuppressWarnings("unused")
   private static final String TAG = VideoMediaFragment.class.getSimpleName();
   private VideoView videoView;
+  private View rootView;
 
   @Nullable
   @Override
   public View onCreateView(LayoutInflater inflater,
                            @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
     super.onCreateView(inflater, container, savedInstanceState);
-    return inflater.inflate(R.layout.view_video, container, false);
+    rootView = inflater.inflate(R.layout.view_video, container, false);
+    rootView.setOnClickListener(new View.OnClickListener() {
+      @Override
+      public void onClick(View view) {
+        if (pageClickListener != null) {
+          pageClickListener.onClick(view);
+        }
+        Log.d(TAG, "onClick: video");
+        if (isCompleted) {
+          videoView.seekTo(0);
+          videoView.resume();
+          isCompleted = false;
+        }
+      }
+    });
+    return rootView;
   }
 
   @Override
@@ -42,6 +58,8 @@ public class VideoMediaFragment extends MediaViewActivity.MediaFragment {
     super.onViewCreated(view, savedInstanceState);
     videoView = (VideoView) view.findViewById(R.id.media_video);
   }
+
+  private boolean isCompleted = false;
 
   @Override
   public void onStart() {
@@ -54,16 +72,18 @@ public class VideoMediaFragment extends MediaViewActivity.MediaFragment {
     videoView.setOnPreparedListener(new MediaPlayer.OnPreparedListener() {
       @Override
       public void onPrepared(MediaPlayer mediaPlayer) {
+//        Log.d(TAG, "onPrepared: ");
         videoView.start();
       }
     });
     videoView.setOnCompletionListener(new MediaPlayer.OnCompletionListener() {
       @Override
       public void onCompletion(MediaPlayer mediaPlayer) {
+//        Log.d(TAG, "onCompletion: ");
         videoView.stopPlayback();
+        isCompleted = true;
       }
     });
-    Log.d(TAG, "onStart: video: " + url);
     videoView.setVideoURI(Uri.parse(url));
   }
 
@@ -102,5 +122,11 @@ public class VideoMediaFragment extends MediaViewActivity.MediaFragment {
     videoView.setOnCompletionListener(null);
     videoView.setVideoURI(null);
     super.onStop();
+  }
+
+  @Override
+  public void onDestroyView() {
+    rootView.setOnClickListener(null);
+    super.onDestroyView();
   }
 }

--- a/app/src/main/java/com/freshdigitable/udonroad/VideoMediaFragment.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/VideoMediaFragment.java
@@ -14,6 +14,11 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.VideoView;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+
 import twitter4j.ExtendedMediaEntity;
 
 /**
@@ -63,13 +68,31 @@ public class VideoMediaFragment extends MediaViewActivity.MediaFragment {
   }
 
   private String selectVideo() {
+    final List<ExtendedMediaEntity.Variant> playableMedia = findPlayableMedia();
+    if (playableMedia.size() == 0) {
+      return null;
+    } else if (playableMedia.size() == 1) {
+      return playableMedia.get(0).getUrl();
+    }
+
+    Collections.sort(playableMedia, new Comparator<ExtendedMediaEntity.Variant>() {
+      @Override
+      public int compare(ExtendedMediaEntity.Variant l, ExtendedMediaEntity.Variant r) {
+        return l.getBitrate() - r.getBitrate();
+      }
+    });
+    return playableMedia.get(1).getUrl();
+  }
+
+  private List<ExtendedMediaEntity.Variant> findPlayableMedia() {
     final ExtendedMediaEntity.Variant[] videoVariants = mediaEntity.getVideoVariants();
+    List<ExtendedMediaEntity.Variant> res = new ArrayList<>(videoVariants.length);
     for (ExtendedMediaEntity.Variant v : videoVariants) {
       if (v.getContentType().equals("video/mp4")) {
-        return v.getUrl();
+        res.add(v);
       }
     }
-    return null;
+    return res;
   }
 
   @Override

--- a/app/src/main/java/com/freshdigitable/udonroad/VideoMediaFragment.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/VideoMediaFragment.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2016. UdonRoad by Akihito Matsuda (akihito104)
+ */
+
+package com.freshdigitable.udonroad;
+
+import android.media.MediaPlayer;
+import android.net.Uri;
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.util.Log;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.VideoView;
+
+import twitter4j.ExtendedMediaEntity;
+
+/**
+ * Created by akihit on 2016/07/17.
+ */
+public class VideoMediaFragment extends MediaViewActivity.MediaFragment {
+  @SuppressWarnings("unused")
+  private static final String TAG = VideoMediaFragment.class.getSimpleName();
+  private VideoView videoView;
+
+  @Nullable
+  @Override
+  public View onCreateView(LayoutInflater inflater,
+                           @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
+    super.onCreateView(inflater, container, savedInstanceState);
+    return inflater.inflate(R.layout.view_video, container, false);
+  }
+
+  @Override
+  public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
+    super.onViewCreated(view, savedInstanceState);
+    videoView = (VideoView) view.findViewById(R.id.media_video);
+  }
+
+  @Override
+  public void onStart() {
+    super.onStart();
+    final String url = selectVideo();
+    if (url == null) {
+      return;
+    }
+
+    videoView.setOnPreparedListener(new MediaPlayer.OnPreparedListener() {
+      @Override
+      public void onPrepared(MediaPlayer mediaPlayer) {
+        videoView.start();
+      }
+    });
+    videoView.setOnCompletionListener(new MediaPlayer.OnCompletionListener() {
+      @Override
+      public void onCompletion(MediaPlayer mediaPlayer) {
+        videoView.stopPlayback();
+      }
+    });
+    Log.d(TAG, "onStart: video: " + url);
+    videoView.setVideoURI(Uri.parse(url));
+  }
+
+  private String selectVideo() {
+    final ExtendedMediaEntity.Variant[] videoVariants = mediaEntity.getVideoVariants();
+    for (ExtendedMediaEntity.Variant v : videoVariants) {
+      if (v.getContentType().equals("video/mp4")) {
+        return v.getUrl();
+      }
+    }
+    return null;
+  }
+
+  @Override
+  public void onStop() {
+    videoView.stopPlayback();
+    videoView.setOnPreparedListener(null);
+    videoView.setOnCompletionListener(null);
+    videoView.setVideoURI(null);
+    super.onStop();
+  }
+}

--- a/app/src/main/java/com/freshdigitable/udonroad/VideoMediaFragment.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/VideoMediaFragment.java
@@ -36,20 +36,6 @@ public class VideoMediaFragment extends MediaViewActivity.MediaFragment {
                            @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
     super.onCreateView(inflater, container, savedInstanceState);
     rootView = inflater.inflate(R.layout.view_video, container, false);
-    rootView.setOnClickListener(new View.OnClickListener() {
-      @Override
-      public void onClick(View view) {
-        if (pageClickListener != null) {
-          pageClickListener.onClick(view);
-        }
-        Log.d(TAG, "onClick: video");
-        if (isCompleted) {
-          videoView.seekTo(0);
-          videoView.resume();
-          isCompleted = false;
-        }
-      }
-    });
     return rootView;
   }
 
@@ -68,6 +54,23 @@ public class VideoMediaFragment extends MediaViewActivity.MediaFragment {
     if (url == null) {
       return;
     }
+
+    rootView.setOnClickListener(new View.OnClickListener() {
+      @Override
+      public void onClick(View view) {
+        if (pageClickListener != null) {
+          pageClickListener.onClick(view);
+        }
+        Log.d(TAG, "onClick: video");
+        if (isCompleted) {
+          final VideoView video = (VideoView) view.findViewById(R.id.media_video);
+          video.seekTo(0);
+          video.resume();
+          isCompleted = false;
+        }
+      }
+    });
+    rootView.setOnTouchListener(super.touchListener);
 
     videoView.setOnPreparedListener(new MediaPlayer.OnPreparedListener() {
       @Override
@@ -121,12 +124,8 @@ public class VideoMediaFragment extends MediaViewActivity.MediaFragment {
     videoView.setOnPreparedListener(null);
     videoView.setOnCompletionListener(null);
     videoView.setVideoURI(null);
-    super.onStop();
-  }
-
-  @Override
-  public void onDestroyView() {
     rootView.setOnClickListener(null);
-    super.onDestroyView();
+    rootView.setOnTouchListener(null);
+    super.onStop();
   }
 }

--- a/app/src/main/java/com/freshdigitable/udonroad/fab/FlingableFAB.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/fab/FlingableFAB.java
@@ -39,6 +39,7 @@ public class FlingableFAB extends FloatingActionButton {
         final int action = motionEvent.getAction();
         if (action == MotionEvent.ACTION_DOWN) {
           old = MotionEvent.obtain(motionEvent);
+          flingListener.onStart();
           if (actionIndicatorHelper != null) {
             actionIndicatorHelper.onStart();
           }
@@ -47,6 +48,7 @@ public class FlingableFAB extends FloatingActionButton {
         final Direction direction = Direction.getDirection(old, motionEvent);
         if (action == MotionEvent.ACTION_MOVE) {
 //          Log.d(TAG, "onTouch: " + direction);
+          flingListener.onMoving(direction);
           if (actionIndicatorHelper != null) {
             actionIndicatorHelper.onMoving(direction);
           }

--- a/app/src/main/java/com/freshdigitable/udonroad/realmdata/RealmHomeTimelineFragment.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/realmdata/RealmHomeTimelineFragment.java
@@ -61,8 +61,20 @@ public class RealmHomeTimelineFragment extends RealmTimelineFragment {
   @Override
   public void onStop() {
     Log.d(TAG, "onStop: ");
-    userStream.disconnect();
     super.onStop();
+  }
+
+  @Override
+  public void onDestroyView() {
+    Log.d(TAG, "onDestroyView: ");
+    super.onDestroyView();
+  }
+
+  @Override
+  public void onDestroy() {
+    Log.d(TAG, "onDestroy: ");
+    userStream.disconnect();
+    super.onDestroy();
   }
 
   @Override

--- a/app/src/main/java/com/freshdigitable/udonroad/realmdata/RealmTimelineAdapter.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/realmdata/RealmTimelineAdapter.java
@@ -45,7 +45,6 @@ public class RealmTimelineAdapter extends TimelineAdapter {
 
   public void openRealm(RealmConfiguration config) {
     Log.d(TAG, "openRealm: ");
-    Realm.deleteRealm(config);
     realm = Realm.getInstance(config);
     defaultTimeline();
   }
@@ -53,12 +52,6 @@ public class RealmTimelineAdapter extends TimelineAdapter {
   public void closeRealm() {
     Log.d(TAG, "closeRealm: ");
     clearSelectedTweet();
-    realm.executeTransaction(new Realm.Transaction() {
-      @Override
-      public void execute(Realm realm) {
-        realm.deleteAll();
-      }
-    });
     realm.close();
   }
 

--- a/app/src/main/java/com/freshdigitable/udonroad/realmdata/RealmTimelineFragment.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/realmdata/RealmTimelineFragment.java
@@ -15,6 +15,7 @@ import com.freshdigitable.udonroad.TimelineFragment;
 
 import java.util.List;
 
+import io.realm.Realm;
 import io.realm.RealmConfiguration;
 import rx.Observable;
 import rx.android.schedulers.AndroidSchedulers;
@@ -44,6 +45,13 @@ public abstract class RealmTimelineFragment extends TimelineFragment {
     Log.d(TAG, "onStop: ");
     adapter.closeRealm();
     super.onStop();
+  }
+
+  @Override
+  public void onDestroy() {
+    Log.d(TAG, "onDestroy: ");
+    Realm.deleteRealm(createRealmConfiguration());
+    super.onDestroy();
   }
 
   public abstract RealmConfiguration createRealmConfiguration();

--- a/app/src/main/res/drawable/ic_play_circle_outline.xml
+++ b/app/src/main/res/drawable/ic_play_circle_outline.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:viewportHeight="24.0" android:viewportWidth="24.0" android:width="24dp">
+    <path android:fillColor="#FFFFFF" android:pathData="M10,16.5l6,-4.5 -6,-4.5v9zM12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM12,20c-4.41,0 -8,-3.59 -8,-8s3.59,-8 8,-8 8,3.59 8,8 -3.59,8 -8,8z"/>
+</vector>

--- a/app/src/main/res/drawable/ld_play_icon.xml
+++ b/app/src/main/res/drawable/ld_play_icon.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2016. UdonRoad by Akihito Matsuda (akihito104)
+  -->
+
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@drawable/s_play_circle"
+          android:width="24dp" android:height="24dp"/>
+    <item android:drawable="@drawable/ic_play_circle_outline"
+        android:height="24dp"
+        android:width="24dp"
+        />
+</layer-list>

--- a/app/src/main/res/drawable/s_play_circle.xml
+++ b/app/src/main/res/drawable/s_play_circle.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2016. UdonRoad by Akihito Matsuda (akihito104)
+  -->
+
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+    <size android:width="24dp" android:height="24dp"/>
+    <solid android:color="@color/colorImmersiveLayerBackground"/>
+</shape>

--- a/app/src/main/res/layout/activity_media_view.xml
+++ b/app/src/main/res/layout/activity_media_view.xml
@@ -10,39 +10,47 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         >
-        <android.support.v7.widget.Toolbar
-            android:id="@+id/media_toolbar"
-            android:layout_width="match_parent"
-            android:layout_height="?attr/actionBarSize"
-            android:background="#3000"
-            app:titleTextColor="#fff"
-            />
         <android.support.v4.view.ViewPager
             android:id="@+id/media_pager"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             />
-        <com.freshdigitable.udonroad.fab.ActionIndicatorView
-            android:id="@+id/media_indicator"
-            android:layout_width="52dp"
-            android:layout_height="48dp"
-            android:layout_marginBottom="182dp"
-            android:src="@drawable/ic_add"
-            android:background="#3000"
-            android:contentDescription="@string/desc_fling_indicator"
-            android:layout_gravity="bottom|center_horizontal"
-            android:visibility="gone"
-            tools:visibility="visible"
-            />
-        <com.freshdigitable.udonroad.fab.FlingableFAB
-            android:id="@+id/media_ffab"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center_horizontal|bottom"
-            android:layout_marginBottom="64dp"
-            android:src="@drawable/ic_add"
-            app:backgroundTint="#3000"
-            app:fabSize="normal"
-            />
+
+        <FrameLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:fitsSystemWindows="true"
+            >
+            <android.support.v7.widget.Toolbar
+                android:id="@+id/media_toolbar"
+                android:layout_width="match_parent"
+                android:layout_height="?attr/actionBarSize"
+                android:background="@color/colorImmersiveLayerBackground"
+                app:titleTextColor="#fff"
+                />
+            <com.freshdigitable.udonroad.fab.ActionIndicatorView
+                android:id="@+id/media_indicator"
+                android:layout_width="52dp"
+                android:layout_height="48dp"
+                android:layout_marginBottom="150dp"
+                android:src="@drawable/ic_add"
+                android:background="@color/colorImmersiveLayerBackground"
+                android:contentDescription="@string/desc_fling_indicator"
+                android:layout_gravity="bottom|center_horizontal"
+                android:visibility="gone"
+                tools:visibility="visible"
+                />
+            <com.freshdigitable.udonroad.fab.FlingableFAB
+                android:id="@+id/media_ffab"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_horizontal|bottom"
+                android:layout_marginBottom="32dp"
+                android:src="@drawable/ic_add"
+                app:backgroundTint="@color/colorImmersiveLayerBackground"
+                app:fabSize="normal"
+                />
+        </FrameLayout>
+
     </FrameLayout>
 </layout>

--- a/app/src/main/res/layout/activity_media_view.xml
+++ b/app/src/main/res/layout/activity_media_view.xml
@@ -10,6 +10,13 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         >
+        <android.support.v7.widget.Toolbar
+            android:id="@+id/media_toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            android:background="#3000"
+            app:titleTextColor="#fff"
+            />
         <android.support.v4.view.ViewPager
             android:id="@+id/media_pager"
             android:layout_width="match_parent"
@@ -19,7 +26,7 @@
             android:id="@+id/media_indicator"
             android:layout_width="52dp"
             android:layout_height="48dp"
-            android:layout_marginBottom="150dp"
+            android:layout_marginBottom="182dp"
             android:src="@drawable/ic_add"
             android:background="#3000"
             android:contentDescription="@string/desc_fling_indicator"
@@ -32,7 +39,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center_horizontal|bottom"
-            android:layout_marginBottom="32dp"
+            android:layout_marginBottom="64dp"
             android:src="@drawable/ic_add"
             app:backgroundTint="#3000"
             app:fabSize="normal"

--- a/app/src/main/res/layout/activity_media_view.xml
+++ b/app/src/main/res/layout/activity_media_view.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2016. UdonRoad by Akihito Matsuda (akihito104)
+  -->
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        xmlns:tools="http://schemas.android.com/tools"
+    >
+    <FrameLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        >
+        <android.support.v4.view.ViewPager
+            android:id="@+id/media_pager"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            />
+        <com.freshdigitable.udonroad.fab.ActionIndicatorView
+            android:id="@+id/media_indicator"
+            android:layout_width="52dp"
+            android:layout_height="48dp"
+            android:layout_marginBottom="150dp"
+            android:src="@drawable/ic_add"
+            android:background="#3000"
+            android:contentDescription="@string/desc_fling_indicator"
+            android:layout_gravity="bottom|center_horizontal"
+            android:visibility="gone"
+            tools:visibility="visible"
+            />
+        <com.freshdigitable.udonroad.fab.FlingableFAB
+            android:id="@+id/media_ffab"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_horizontal|bottom"
+            android:layout_marginBottom="32dp"
+            android:src="@drawable/ic_add"
+            app:backgroundTint="#3000"
+            app:fabSize="normal"
+            />
+    </FrameLayout>
+</layout>

--- a/app/src/main/res/layout/view_quoted_status.xml
+++ b/app/src/main/res/layout/view_quoted_status.xml
@@ -5,6 +5,7 @@
 
 <merge xmlns:android="http://schemas.android.com/apk/res/android"
        xmlns:tools="http://schemas.android.com/tools"
+       xmlns:app="http://schemas.android.com/apk/res-auto"
     >
 
     <!--<RelativeLayout android:layout_width="match_parent"-->
@@ -136,7 +137,7 @@
         tools:visibility="visible"
         />
 
-    <LinearLayout
+    <com.freshdigitable.udonroad.MediaContainer
         android:id="@+id/q_image_group"
         android:layout_width="match_parent"
         android:layout_height="@dimen/tweet_user_icon"
@@ -146,48 +147,8 @@
         android:orientation="horizontal"
         android:visibility="gone"
         tools:visibility="visible"
-        >
-        <ImageView
-            android:id="@+id/q_image_1"
-            android:layout_width="0dp"
-            android:layout_height="match_parent"
-            android:layout_weight="1"
-            android:contentDescription="@string/tweet_media_descs"
-            android:visibility="gone"
-            tools:visibility="visible"
-            />
-        <ImageView
-            android:id="@+id/q_image_2"
-            android:layout_width="0dp"
-            android:layout_height="match_parent"
-            android:layout_marginLeft="@dimen/grid_margin"
-            android:layout_weight="1"
-            android:contentDescription="@string/tweet_media_descs"
-            android:visibility="gone"
-            tools:visibility="visible"
-            />
-        <ImageView
-            android:id="@+id/q_image_3"
-            android:layout_width="0dp"
-            android:layout_height="match_parent"
-            android:layout_marginLeft="@dimen/grid_margin"
-            android:layout_weight="1"
-            android:contentDescription="@string/tweet_media_descs"
-            android:visibility="gone"
-            tools:visibility="visible"
-            />
-        <ImageView
-            android:id="@+id/q_image_4"
-            android:layout_width="0dp"
-            android:layout_height="match_parent"
-            android:layout_marginLeft="@dimen/grid_margin"
-            android:layout_weight="1"
-            android:contentDescription="@string/tweet_media_descs"
-            android:visibility="gone"
-            tools:visibility="visible"
-            />
-    </LinearLayout>
-
+        app:thumbCount="4"
+        />
     <!--</RelativeLayout>-->
 
 </merge>

--- a/app/src/main/res/layout/view_status.xml
+++ b/app/src/main/res/layout/view_status.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <merge xmlns:android="http://schemas.android.com/apk/res/android"
        xmlns:tools="http://schemas.android.com/tools"
+       xmlns:app="http://schemas.android.com/apk/res-auto"
     >
 
     <!--<RelativeLayout android:layout_width="match_parent"-->
@@ -179,7 +180,7 @@
             tools:visibility="visible"
             />
 
-        <LinearLayout
+        <com.freshdigitable.udonroad.MediaContainer
             android:id="@+id/tl_image_group"
             android:layout_width="wrap_content"
             android:layout_height="@dimen/tweet_user_icon"
@@ -193,47 +194,8 @@
             android:orientation="horizontal"
             android:visibility="gone"
             tools:visibility="visible"
-            >
-            <ImageView
-                android:id="@+id/tl_image_1"
-                android:layout_width="0dp"
-                android:layout_height="match_parent"
-                android:layout_weight="1"
-                android:contentDescription="@string/tweet_media_descs"
-                android:visibility="gone"
-                tools:visibility="visible"
-                />
-            <ImageView
-                android:id="@+id/tl_image_2"
-                android:layout_width="0dp"
-                android:layout_height="match_parent"
-                android:layout_marginLeft="@dimen/grid_margin"
-                android:layout_weight="1"
-                android:contentDescription="@string/tweet_media_descs"
-                android:visibility="gone"
-                tools:visibility="visible"
-                />
-            <ImageView
-                android:id="@+id/tl_image_3"
-                android:layout_width="0dp"
-                android:layout_height="match_parent"
-                android:layout_marginLeft="@dimen/grid_margin"
-                android:layout_weight="1"
-                android:contentDescription="@string/tweet_media_descs"
-                android:visibility="gone"
-                tools:visibility="visible"
-                />
-            <ImageView
-                android:id="@+id/tl_image_4"
-                android:layout_width="0dp"
-                android:layout_height="match_parent"
-                android:layout_marginLeft="@dimen/grid_margin"
-                android:layout_weight="1"
-                android:contentDescription="@string/tweet_media_descs"
-                android:visibility="gone"
-                tools:visibility="visible"
-                />
-        </LinearLayout>
+            app:thumbCount="4"
+            />
 
         <com.freshdigitable.udonroad.QuotedStatusView
             android:id="@+id/tl_quoted"

--- a/app/src/main/res/layout/view_video.xml
+++ b/app/src/main/res/layout/view_video.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2016. UdonRoad by Akihito Matsuda (akihito104)
+  -->
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+           android:layout_height="match_parent"
+           android:layout_width="match_parent"
+    >
+    <VideoView
+        android:id="@+id/media_video"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_gravity="center"
+        />
+</FrameLayout>

--- a/app/src/main/res/layout/view_video.xml
+++ b/app/src/main/res/layout/view_video.xml
@@ -3,8 +3,9 @@
   ~ Copyright (c) 2016. UdonRoad by Akihito Matsuda (akihito104)
   -->
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-           android:layout_height="match_parent"
-           android:layout_width="match_parent"
+             android:layout_height="wrap_content"
+             android:layout_width="match_parent"
+             xmlns:tools="http://schemas.android.com/tools"
     >
     <VideoView
         android:id="@+id/media_video"
@@ -12,4 +13,27 @@
         android:layout_height="match_parent"
         android:layout_gravity="center"
         />
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom|center_horizontal"
+        android:background="@color/colorImmersiveLayerBackground"
+        >
+        <TextView
+            android:id="@+id/media_progressText"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="@dimen/grid_margin"
+            android:textSize="14sp"
+            android:textColor="#fff"
+            tools:text="1:00"
+            />
+        <ProgressBar
+            android:id="@+id/media_progressBar"
+            style="?android:attr/progressBarStyleHorizontal"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_vertical"
+            />
+    </LinearLayout>
 </FrameLayout>

--- a/app/src/main/res/values-v19/styles.xml
+++ b/app/src/main/res/values-v19/styles.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2016. UdonRoad by Akihito Matsuda (akihito104)
+  -->
+
+<resources>
+    <style name="Theme.AppTheme.TranslucentStatusBar" parent="Theme.AppCompat.Light.NoActionBar">
+        <item name="android:windowTranslucentStatus">true</item>
+    </style>
+</resources>

--- a/app/src/main/res/values-v21/styles.xml
+++ b/app/src/main/res/values-v21/styles.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2016. UdonRoad by Akihito Matsuda (akihito104)
+  -->
+
+<resources>
+    <style name="Theme.AppTheme.TranslucentStatusBar" parent="Theme.AppCompat.Light.NoActionBar">
+        <item name="android:statusBarColor">@color/colorImmersiveLayerBackground</item>
+        <item name="android:navigationBarColor">@color/colorImmersiveLayerBackground</item>
+    </style>
+</resources>

--- a/app/src/main/res/values-v23/styles.xml
+++ b/app/src/main/res/values-v23/styles.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2016. UdonRoad by Akihito Matsuda (akihito104)
+  -->
+
+<resources>
+    <style name="Theme.AppTheme.TranslucentStatusBar" parent="Theme.AppCompat.Light.NoActionBar">
+        <item name="android:statusBarColor">@color/colorImmersiveLayerBackground</item>
+        <item name="android:navigationBarColor">@color/colorImmersiveLayerBackground</item>
+        <item name="android:windowLightStatusBar">true</item>
+    </style>
+</resources>

--- a/app/src/main/res/values/attr.xml
+++ b/app/src/main/res/values/attr.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2016. UdonRoad by Akihito Matsuda (akihito104)
+  -->
+
+<resources>
+    <declare-styleable name="MediaContainer">
+        <attr name="thumbCount" format="integer" />
+    </declare-styleable>
+</resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -7,4 +7,5 @@
     <color name="colorTwitterActionNormalTransparent">#3FAAB8C2</color>
     <color name="colorTwitterActionRetweeted">#19CF86</color>
     <color name="colorTwitterActionFaved">#E81C4F</color>
+    <color name="colorImmersiveLayerBackground">#3000</color>
 </resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -8,4 +8,5 @@
     <dimen name="grid_margin">4dp</dimen>
     <dimen name="small_user_icon">16dp</dimen>
     <dimen name="selected_indicator_size">24dp</dimen>
+    <dimen name="action_bar_elevation">4dp</dimen>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -34,4 +34,5 @@
     <string name="detail_fav_delete_failed">like delete failure…</string>
     <string name="detail_fav_delete_success">like destroy successed</string>
     <string name="desc_fling_indicator">action indicator</string>
+    <string name="media_remain_time">%1$d:%2$02d</string>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -13,4 +13,5 @@
         <item name="color">@android:color/primary_text_dark</item>
     </style>
 
+    <style name="Theme.AppTheme.TranslucentStatusBar" parent="Theme.AppCompat.Light.NoActionBar" />
 </resources>


### PR DESCRIPTION
# TODO

- [x] ExtendedMediaEntityとそのサムネイルを表示するカスタムビューをつくる
- [x] サムネイルをタップして画像を表示する #65 
- [x] サムネイルをタップして動画を表示する #66
    - [x] gif animeを再生できるようにする
    - [x] 動画を最後まで見たら頭出しできるようにする
    - [x] 動画の進捗バーを表示する
    - [x] 重すぎない動画を選んで再生する
- [x] 表示した動画像をImmersiveに表示する #67
    - [x] 縦方向のスワイプを無視する
- [x] RT/favのFFABを表示する #68
- [x] 複数の動画像をImmersiveな状態で切り替えられるようにする #69 
- [x] サムネイルで静止画と動画とを区別できるようにする

refs: add image viewer #7 