### PR TITLE
[WIP] not to show blocked / muted user's tweets

### DIFF
--- a/app/src/androidTest/java/com/freshdigitable/udonroad/MainActivityInstTestBase.java
+++ b/app/src/androidTest/java/com/freshdigitable/udonroad/MainActivityInstTestBase.java
@@ -32,7 +32,6 @@ import com.freshdigitable.udonroad.util.UserUtil;
 
 import org.junit.After;
 import org.junit.Before;
-import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
@@ -44,6 +43,7 @@ import javax.inject.Inject;
 import rx.Observable;
 import rx.Subscriber;
 import rx.schedulers.Schedulers;
+import twitter4j.IDs;
 import twitter4j.PagableResponseList;
 import twitter4j.Paging;
 import twitter4j.Status;
@@ -65,6 +65,7 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyLong;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -168,6 +169,19 @@ public abstract class MainActivityInstTestBase {
         .thenReturn(Observable.<PagableResponseList<User>>empty());
     when(twitterApi.getId())
         .thenReturn(Observable.just(2000L));
+
+    final IDs ignoringUserIDsMock = mock(IDs.class);
+    when(ignoringUserIDsMock.getIDs())
+        .thenReturn(new long[0]);
+    when(ignoringUserIDsMock.getNextCursor())
+        .thenReturn(0L);
+    when(ignoringUserIDsMock.getPreviousCursor())
+        .thenReturn(0L);
+    when(twitterApi.getAllBlocksIDs())
+        .thenReturn(Observable.just(ignoringUserIDsMock));
+    when(twitterApi.getAllMutesIDs())
+        .thenReturn(Observable.just(ignoringUserIDsMock));
+
     getRule().launchActivity(getIntent());
     verifyAfterLaunch();
   }
@@ -191,7 +205,7 @@ public abstract class MainActivityInstTestBase {
   }
 
   private static TwitterAPIConfiguration createTwitterAPIConfigMock() {
-    final TwitterAPIConfiguration mock = Mockito.mock(TwitterAPIConfiguration.class);
+    final TwitterAPIConfiguration mock = mock(TwitterAPIConfiguration.class);
     when(mock.getShortURLLength()).thenReturn(23);
     when(mock.getShortURLLengthHttps()).thenReturn(23);
     return mock;

--- a/app/src/main/java/com/freshdigitable/udonroad/ConfigSubscriber.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/ConfigSubscriber.java
@@ -166,4 +166,66 @@ public class ConfigSubscriber {
           }
         }, onErrorAction);
   }
+
+  private FeedbackSubscriber feedback;
+
+  public void setFeedbackSubscriber(FeedbackSubscriber feedback) {
+    this.feedback = feedback;
+  }
+
+  public void createBlock(final long userId) {
+    twitterApi.createBlock(userId)
+        .observeOn(AndroidSchedulers.mainThread())
+        .subscribe(
+            addIgnoringUserAction(),
+            feedback.onErrorDefault(R.string.msg_create_block_failed),
+            feedback.onCompleteDefault(R.string.msg_create_block_success));
+  }
+
+  public void destroyBlock(final long userId) {
+    twitterApi.destroyBlock(userId)
+        .observeOn(AndroidSchedulers.mainThread())
+        .subscribe(
+            removeIgnoringUserAction(),
+            feedback.onErrorDefault(R.string.msg_create_block_failed),
+            feedback.onCompleteDefault(R.string.msg_create_block_success));
+  }
+
+  public void reportSpam(long userId) {
+    twitterApi.reportSpam(userId)
+        .observeOn(AndroidSchedulers.mainThread())
+        .subscribe(
+            addIgnoringUserAction(),
+            feedback.onErrorDefault(R.string.msg_report_spam_failed),
+            feedback.onCompleteDefault(R.string.msg_report_spam_success));
+  }
+
+  public void createMute(long userId) {
+    twitterApi.createMute(userId)
+        .observeOn(AndroidSchedulers.mainThread())
+        .subscribe(
+            addIgnoringUserAction(),
+            feedback.onErrorDefault(R.string.msg_create_mute_failed),
+            feedback.onCompleteDefault(R.string.msg_create_mute_success));
+  }
+
+  @NonNull
+  private Action1<User> addIgnoringUserAction() {
+    return new Action1<User>() {
+      @Override
+      public void call(User user) {
+        configStore.addIgnoringUser(user);
+      }
+    };
+  }
+
+  @NonNull
+  private Action1<User> removeIgnoringUserAction() {
+    return new Action1<User>() {
+      @Override
+      public void call(User user) {
+        configStore.removeIgnoringUser(user);
+      }
+    };
+  }
 }

--- a/app/src/main/java/com/freshdigitable/udonroad/ConfigSubscriber.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/ConfigSubscriber.java
@@ -152,17 +152,17 @@ public class ConfigSubscriber {
                  },
             new Action2<TreeSet<Long>, long[]>() {
               @Override
-              public void call(TreeSet<Long> longs, long[] longs2) {
-                for (long l : longs2) {
-                  longs.add(l);
+              public void call(TreeSet<Long> collector, long[] ids) {
+                for (long l : ids) {
+                  collector.add(l);
                 }
               }
             })
         .observeOn(AndroidSchedulers.mainThread())
         .subscribe(new Action1<Collection<Long>>() {
           @Override
-          public void call(Collection<Long> longs) {
-            configStore.addIgnoringUsers(longs);
+          public void call(Collection<Long> ids) {
+            configStore.replaceIgnoringUsers(ids);
           }
         }, onErrorAction);
   }

--- a/app/src/main/java/com/freshdigitable/udonroad/DataStoreModule.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/DataStoreModule.java
@@ -40,12 +40,14 @@ import twitter4j.User;
 public class DataStoreModule {
   @Provides
   public TypedCache<Status> provideTypedCacheStatus() {
-    return new StatusCacheRealm();
+    final ConfigStore configStore = provideConfigStore();
+    return new StatusCacheRealm(configStore);
   }
 
   @Provides
   public MediaCache provideMediaCache() {
-    return new StatusCacheRealm();
+    final ConfigStore configStore = provideConfigStore();
+    return new StatusCacheRealm(configStore);
   }
 
   @Provides
@@ -55,13 +57,14 @@ public class DataStoreModule {
 
   @Provides
   public SortedCache<Status> provideSortedCacheStatus() {
-    final StatusCacheRealm statusCacheRealm = new StatusCacheRealm();
-    return new TimelineStoreRealm(statusCacheRealm);
+    final TypedCache<Status> statusCacheRealm = provideTypedCacheStatus();
+    final ConfigStore configStore = provideConfigStore();
+    return new TimelineStoreRealm(statusCacheRealm, configStore);
   }
 
   @Provides
   public SortedCache<User> provideSortedCacheUser() {
-    final UserCacheRealm userCacheRealm = new UserCacheRealm();
+    final TypedCache<User> userCacheRealm = provideTypedCacheUser();
     return new UserSortedCacheRealm(userCacheRealm);
   }
 

--- a/app/src/main/java/com/freshdigitable/udonroad/MainActivity.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/MainActivity.java
@@ -164,7 +164,7 @@ public class MainActivity
   }
 
   @Override
-  public void onClicked(View view, User user) {
+  public void onUserIconClicked(View view, User user) {
     if (tweetInputFragment != null && tweetInputFragment.isStatusInputViewVisible()) {
       return;
     }

--- a/app/src/main/java/com/freshdigitable/udonroad/MainActivity.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/MainActivity.java
@@ -234,6 +234,7 @@ public class MainActivity
     userStream.connect(homeTimeline);
     configSubscriber.verifyCredencials();
     configSubscriber.fetchTwitterAPIConfig();
+    configSubscriber.fetchAllIgnoringUsers();
     setupNavigationDrawer();
 
     binding.mainToolbar.setTitle("Home");

--- a/app/src/main/java/com/freshdigitable/udonroad/StatusDetailFragment.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/StatusDetailFragment.java
@@ -117,13 +117,13 @@ public class StatusDetailFragment extends Fragment {
     icon.setOnClickListener(new View.OnClickListener() {
       @Override
       public void onClick(View view) {
-        userIconClickedListener.onClicked(view, user);
+        userIconClickedListener.onUserIconClicked(view, user);
       }
     });
     statusView.getUserName().setOnClickListener(new View.OnClickListener() {
       @Override
       public void onClick(View view) {
-        userIconClickedListener.onClicked(icon, user);
+        userIconClickedListener.onUserIconClicked(icon, user);
       }
     });
     statusView.getMediaContainer().setOnMediaClickListener(new OnMediaClickListener() {
@@ -301,7 +301,7 @@ public class StatusDetailFragment extends Fragment {
     } else {
       return new OnUserIconClickedListener() {
         @Override
-        public void onClicked(View view, User user) {
+        public void onUserIconClicked(View view, User user) {
           UserInfoActivity.start(activity, user, view);
         }
       };

--- a/app/src/main/java/com/freshdigitable/udonroad/StatusViewBase.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/StatusViewBase.java
@@ -260,7 +260,7 @@ public abstract class StatusViewBase extends RelativeLayout {
   public abstract void setUnselectedColor();
 
   interface OnUserIconClickedListener {
-    void onClicked(View view, User user);
+    void onUserIconClicked(View view, User user);
   }
 
   public TextView getUserName() {

--- a/app/src/main/java/com/freshdigitable/udonroad/TimelineAdapter.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/TimelineAdapter.java
@@ -117,7 +117,7 @@ public class TimelineAdapter<T> extends RecyclerView.Adapter<TimelineAdapter.Vie
     itemView.getIcon().setOnClickListener(new View.OnClickListener() {
       @Override
       public void onClick(View v) {
-        userIconClickedListener.onClicked(v, user);
+        userIconClickedListener.onUserIconClicked(v, user);
       }
     });
   }

--- a/app/src/main/java/com/freshdigitable/udonroad/TimelineFragment.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/TimelineFragment.java
@@ -318,7 +318,7 @@ public class TimelineFragment<T> extends Fragment {
     } else {
       return new OnUserIconClickedListener() {
         @Override
-        public void onClicked(View view, User user) {
+        public void onUserIconClicked(View view, User user) {
           // nop
         }
       };

--- a/app/src/main/java/com/freshdigitable/udonroad/TwitterApi.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/TwitterApi.java
@@ -26,6 +26,7 @@ import javax.inject.Inject;
 import rx.Observable;
 import rx.Subscriber;
 import rx.schedulers.Schedulers;
+import twitter4j.IDs;
 import twitter4j.PagableResponseList;
 import twitter4j.Paging;
 import twitter4j.Relationship;
@@ -460,6 +461,44 @@ public class TwitterApi {
         }
       }
     }).subscribeOn(Schedulers.io());
+  }
+
+  public Observable<IDs> getBlocksIDs() {
+    return getBlocksIDs(-1);
+  }
+
+  public Observable<IDs> getBlocksIDs(final long cursor) {
+    return Observable.create(new Observable.OnSubscribe<IDs>() {
+      @Override
+      public void call(Subscriber<? super IDs> subscriber) {
+        try {
+          final IDs blocksIDs = twitter.getBlocksIDs(cursor);
+          subscriber.onNext(blocksIDs);
+          subscriber.onCompleted();
+        } catch (TwitterException e) {
+          subscriber.onError(e);
+        }
+      }
+    }).subscribeOn(Schedulers.io());
+  }
+
+  public Observable<IDs> getMutesIDs() {
+    return getMutesIDs(-1);
+  }
+
+  public Observable<IDs> getMutesIDs(final long cursor) {
+    return Observable.create(new Observable.OnSubscribe<IDs>() {
+      @Override
+      public void call(Subscriber<? super IDs> subscriber) {
+        try {
+          final IDs mutesIDs = twitter.getMutesIDs(cursor);
+          subscriber.onNext(mutesIDs);
+          subscriber.onCompleted();
+        } catch (TwitterException e) {
+          subscriber.onError(e);
+        }
+      }
+    });
   }
 
   public Twitter getTwitter() {

--- a/app/src/main/java/com/freshdigitable/udonroad/TwitterApi.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/TwitterApi.java
@@ -463,17 +463,19 @@ public class TwitterApi {
     }).subscribeOn(Schedulers.io());
   }
 
-  public Observable<IDs> getBlocksIDs() {
-    return getBlocksIDs(-1);
-  }
-
-  public Observable<IDs> getBlocksIDs(final long cursor) {
+  public Observable<IDs> getAllBlocksIDs() {
     return Observable.create(new Observable.OnSubscribe<IDs>() {
       @Override
       public void call(Subscriber<? super IDs> subscriber) {
         try {
-          final IDs blocksIDs = twitter.getBlocksIDs(cursor);
-          subscriber.onNext(blocksIDs);
+          IDs blocksIDs = null;
+          while (blocksIDs == null || blocksIDs.hasNext()) {
+            final long cursor = blocksIDs == null
+                ? -1
+                : blocksIDs.getNextCursor();
+            blocksIDs = twitter.getBlocksIDs(cursor);
+            subscriber.onNext(blocksIDs);
+          }
           subscriber.onCompleted();
         } catch (TwitterException e) {
           subscriber.onError(e);
@@ -482,23 +484,25 @@ public class TwitterApi {
     }).subscribeOn(Schedulers.io());
   }
 
-  public Observable<IDs> getMutesIDs() {
-    return getMutesIDs(-1);
-  }
-
-  public Observable<IDs> getMutesIDs(final long cursor) {
+  public Observable<IDs> getAllMutesIDs() {
     return Observable.create(new Observable.OnSubscribe<IDs>() {
       @Override
       public void call(Subscriber<? super IDs> subscriber) {
         try {
-          final IDs mutesIDs = twitter.getMutesIDs(cursor);
-          subscriber.onNext(mutesIDs);
+          IDs mutesIDs = null;
+          while (mutesIDs == null || mutesIDs.hasNext()) {
+            final long cursor = mutesIDs == null
+                ? -1
+                : mutesIDs.getNextCursor();
+            mutesIDs = twitter.getMutesIDs(cursor);
+            subscriber.onNext(mutesIDs);
+          }
           subscriber.onCompleted();
         } catch (TwitterException e) {
           subscriber.onError(e);
         }
       }
-    });
+    }).subscribeOn(Schedulers.io());
   }
 
   public Twitter getTwitter() {

--- a/app/src/main/java/com/freshdigitable/udonroad/UserInfoActivity.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/UserInfoActivity.java
@@ -39,6 +39,7 @@ import android.view.animation.AlphaAnimation;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import com.freshdigitable.udonroad.FeedbackSubscriber.SnackbarFeedback;
 import com.freshdigitable.udonroad.TweetInputFragment.TweetSendable;
 import com.freshdigitable.udonroad.UserInfoPagerFragment.UserPageInfo;
 import com.freshdigitable.udonroad.databinding.ActivityUserInfoBinding;
@@ -79,6 +80,8 @@ public class UserInfoActivity extends AppCompatActivity implements TweetSendable
   TwitterApi twitterApi;
   private UserSubscriber<TypedCache<User>> userSubscriber;
   private Subscription subscription;
+  @Inject
+  ConfigSubscriber configSubscriber;
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
@@ -98,8 +101,9 @@ public class UserInfoActivity extends AppCompatActivity implements TweetSendable
     viewPager = (UserInfoPagerFragment) getSupportFragmentManager()
         .findFragmentById(R.id.userInfo_pagerFragment);
     viewPager.setUser(userId);
-    userSubscriber = new UserSubscriber<>(twitterApi, userCache,
-        new FeedbackSubscriber.SnackbarFeedback(viewPager.getView()));
+    final SnackbarFeedback feedback = new SnackbarFeedback(viewPager.getView());
+    userSubscriber = new UserSubscriber<>(twitterApi, userCache, feedback);
+    configSubscriber.setFeedbackSubscriber(feedback);
   }
 
   private void setUpUserInfoView(long userId) {
@@ -232,13 +236,13 @@ public class UserInfoActivity extends AppCompatActivity implements TweetSendable
         // todo
         break;
       case R.id.userInfo_mute:
-        userSubscriber.createMute(parseIntent());
+        configSubscriber.createMute(parseIntent());
         break;
       case R.id.userInfo_block:
-        userSubscriber.createBlock(parseIntent());
+        configSubscriber.createBlock(parseIntent());
         break;
       case R.id.userInfo_r4s:
-        userSubscriber.reportSpam(parseIntent());
+        configSubscriber.reportSpam(parseIntent());
         break;
       case R.id.userInfo_reply_close:
         closeTwitterInputView();

--- a/app/src/main/java/com/freshdigitable/udonroad/UserSubscriber.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/UserSubscriber.java
@@ -63,42 +63,6 @@ public class UserSubscriber<T extends BaseOperation<User>> {
             feedback.onCompleteDefault(R.string.msg_destroy_friendship_success));
   }
 
-  public void createBlock(final long userId) {
-    twitterApi.createBlock(userId)
-        .observeOn(AndroidSchedulers.mainThread())
-        .subscribe(
-            createUpsertAction(),
-            feedback.onErrorDefault(R.string.msg_create_block_failed),
-            feedback.onCompleteDefault(R.string.msg_create_block_success));
-  }
-
-  public void destroyBlock(final long userId) {
-    twitterApi.destroyBlock(userId)
-        .observeOn(AndroidSchedulers.mainThread())
-        .subscribe(
-            createUpsertAction(),
-            feedback.onErrorDefault(R.string.msg_create_block_failed),
-            feedback.onCompleteDefault(R.string.msg_create_block_success));
-  }
-
-  public void reportSpam(long userId) {
-    twitterApi.reportSpam(userId)
-        .observeOn(AndroidSchedulers.mainThread())
-        .subscribe(
-            createUpsertAction(),
-            feedback.onErrorDefault(R.string.msg_report_spam_failed),
-            feedback.onCompleteDefault(R.string.msg_report_spam_success));
-  }
-
-  public void createMute(long userId) {
-    twitterApi.createMute(userId)
-        .observeOn(AndroidSchedulers.mainThread())
-        .subscribe(
-            createUpsertAction(),
-            feedback.onErrorDefault(R.string.msg_create_mute_failed),
-            feedback.onCompleteDefault(R.string.msg_create_mute_success));
-  }
-
   public void fetchFollowers(final long userId, final long cursor) {
     twitterApi.getFollowersList(userId, cursor)
         .observeOn(AndroidSchedulers.mainThread())

--- a/app/src/main/java/com/freshdigitable/udonroad/datastore/ConfigStore.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/datastore/ConfigStore.java
@@ -39,5 +39,7 @@ public interface ConfigStore {
 
   TwitterAPIConfiguration getTwitterAPIConfig();
 
-  void addIgnoringUsers(Collection<Long> iDs);
+  void replaceIgnoringUsers(Collection<Long> iDs);
+
+  boolean isIgnoredUser(long userId);
 }

--- a/app/src/main/java/com/freshdigitable/udonroad/datastore/ConfigStore.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/datastore/ConfigStore.java
@@ -42,4 +42,8 @@ public interface ConfigStore {
   void replaceIgnoringUsers(Collection<Long> iDs);
 
   boolean isIgnoredUser(long userId);
+
+  void addIgnoringUser(User user);
+
+  void removeIgnoringUser(User user);
 }

--- a/app/src/main/java/com/freshdigitable/udonroad/realmdata/ConfigStoreRealm.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/realmdata/ConfigStoreRealm.java
@@ -19,6 +19,10 @@ package com.freshdigitable.udonroad.realmdata;
 import com.freshdigitable.udonroad.datastore.ConfigStore;
 import com.freshdigitable.udonroad.datastore.TypedCache;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
 import io.realm.Realm;
 import io.realm.RealmConfiguration;
 import twitter4j.TwitterAPIConfiguration;
@@ -97,5 +101,20 @@ public class ConfigStoreRealm implements ConfigStore {
   public TwitterAPIConfiguration getTwitterAPIConfig() {
     return realm.where(TwitterAPIConfigurationRealm.class)
         .findFirst();
+  }
+
+  @Override
+  public void addIgnoringUsers(final Collection<Long> iDs) {
+    realm.executeTransaction(new Realm.Transaction() {
+      @Override
+      public void execute(Realm realm) {
+        List<IgnoringUser> ignoringUsers = new ArrayList<>(iDs.size());
+        for (Long id : iDs) {
+          final IgnoringUser iUser = new IgnoringUser(id);
+          ignoringUsers.add(iUser);
+        }
+        realm.insertOrUpdate(ignoringUsers);
+      }
+    });
   }
 }

--- a/app/src/main/java/com/freshdigitable/udonroad/realmdata/ConfigStoreRealm.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/realmdata/ConfigStoreRealm.java
@@ -125,4 +125,29 @@ public class ConfigStoreRealm implements ConfigStore {
         .equalTo("id", userId)
         .findFirst() != null;
   }
+
+  @Override
+  public void addIgnoringUser(User user) {
+    final long userId = user.getId();
+    realm.executeTransaction(new Realm.Transaction() {
+      @Override
+      public void execute(Realm realm) {
+        realm.insertOrUpdate(new IgnoringUser(userId));
+      }
+    });
+  }
+
+  @Override
+  public void removeIgnoringUser(User user) {
+    final long userId = user.getId();
+    realm.executeTransaction(new Realm.Transaction() {
+      @Override
+      public void execute(Realm realm) {
+        realm.where(IgnoringUser.class)
+            .equalTo("id", userId)
+            .findAll()
+            .deleteAllFromRealm();
+      }
+    });
+  }
 }

--- a/app/src/main/java/com/freshdigitable/udonroad/realmdata/ConfigStoreRealm.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/realmdata/ConfigStoreRealm.java
@@ -104,10 +104,11 @@ public class ConfigStoreRealm implements ConfigStore {
   }
 
   @Override
-  public void addIgnoringUsers(final Collection<Long> iDs) {
+  public void replaceIgnoringUsers(final Collection<Long> iDs) {
     realm.executeTransaction(new Realm.Transaction() {
       @Override
       public void execute(Realm realm) {
+        realm.delete(IgnoringUser.class);
         List<IgnoringUser> ignoringUsers = new ArrayList<>(iDs.size());
         for (Long id : iDs) {
           final IgnoringUser iUser = new IgnoringUser(id);
@@ -116,5 +117,12 @@ public class ConfigStoreRealm implements ConfigStore {
         realm.insertOrUpdate(ignoringUsers);
       }
     });
+  }
+
+  @Override
+  public boolean isIgnoredUser(long userId) {
+    return realm.where(IgnoringUser.class)
+        .equalTo("id", userId)
+        .findFirst() != null;
   }
 }

--- a/app/src/main/java/com/freshdigitable/udonroad/realmdata/IgnoringUser.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/realmdata/IgnoringUser.java
@@ -14,30 +14,30 @@
  * limitations under the License.
  */
 
-package com.freshdigitable.udonroad.datastore;
+package com.freshdigitable.udonroad.realmdata;
 
-import java.util.Collection;
-
-import twitter4j.TwitterAPIConfiguration;
-import twitter4j.User;
+import io.realm.RealmModel;
+import io.realm.annotations.PrimaryKey;
+import io.realm.annotations.RealmClass;
 
 /**
- * ConfigStore defines scheme to store user configurations.
+ * IgnoringUser is blocked / muted user by authenticated user.
  *
- * Created by akihit on 2016/07/30.
+ * Created by akihit on 2016/10/03.
  */
-public interface ConfigStore {
-  void open();
+@RealmClass
+public class IgnoringUser implements RealmModel {
+  @PrimaryKey
+  private long id;
 
-  void close();
+  public IgnoringUser() {
+  }
 
-  void addAuthenticatedUser(User authenticatedUser);
+  IgnoringUser(long userId) {
+    this.id = userId;
+  }
 
-  User getAuthenticatedUser(long userId);
-
-  void setTwitterAPIConfig(TwitterAPIConfiguration twitterAPIConfig);
-
-  TwitterAPIConfiguration getTwitterAPIConfig();
-
-  void addIgnoringUsers(Collection<Long> iDs);
+  long getId() {
+    return id;
+  }
 }


### PR DESCRIPTION
refs: ブロック、ミュートしたユーザのツイートをタイムラインに流さない #110 

- [x] blocked/mutedユーザの一覧を取得してからツイートをフェッチする
- [x] blocked/mutedユーザのツイートを、ツイート取得時に破棄する
- [x] ユーザのblock/muteアクションをサブスクライブする