### PR TITLE
[WIP] StatusDetailのデザイン変更

### DIFF
--- a/app/src/main/java/com/freshdigitable/udonroad/LinkableTextView.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/LinkableTextView.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2017. Matsuda, Akihit (akihito104)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.freshdigitable.udonroad;
+
+import android.content.Context;
+import android.content.res.ColorStateList;
+import android.support.v4.content.ContextCompat;
+import android.support.v7.widget.AppCompatTextView;
+import android.text.Layout;
+import android.text.Spannable;
+import android.text.method.LinkMovementMethod;
+import android.text.method.MovementMethod;
+import android.text.style.BackgroundColorSpan;
+import android.text.style.ClickableSpan;
+import android.util.AttributeSet;
+import android.view.MotionEvent;
+import android.widget.TextView;
+
+/**
+ * LinkableTextView is a TextView which is acceptable ClickableSpan and is colored at pressed.
+ *
+ * Created by akihit on 2017/01/05.
+ */
+
+public class LinkableTextView extends AppCompatTextView {
+  public LinkableTextView(Context context) {
+    this(context, null);
+  }
+
+  public LinkableTextView(Context context, AttributeSet attrs) {
+    this(context, attrs, android.R.attr.textViewStyle);
+  }
+
+  public LinkableTextView(Context context, AttributeSet attrs, int defStyleAttr) {
+    super(context, attrs, defStyleAttr);
+    final ColorStateList linkStateList
+        = ContextCompat.getColorStateList(getContext(), R.color.selector_link_text);
+    setMovementMethod(ColorStateLinkMovementMethod.getInstance(linkStateList));
+  }
+
+  private static class ColorStateLinkMovementMethod extends LinkMovementMethod {
+    private static ColorStateLinkMovementMethod movementMethod;
+    private final BackgroundColorSpan pressedBackground;
+
+    @Override
+    public boolean onTouchEvent(TextView widget, Spannable buffer, MotionEvent event) {
+      final boolean res = super.onTouchEvent(widget, buffer, event);
+      final int action = event.getAction();
+      if (action == MotionEvent.ACTION_DOWN) {
+        final ClickableSpan[] clickableSpans = findClickableSpan(widget, buffer, event);
+        if (clickableSpans.length > 0) {
+          final int spanStart = buffer.getSpanStart(clickableSpans[0]);
+          final int spanEnd = buffer.getSpanEnd(clickableSpans[0]);
+          buffer.setSpan(pressedBackground, spanStart, spanEnd, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
+        }
+      } else if (action == MotionEvent.ACTION_UP) {
+        buffer.removeSpan(pressedBackground);
+      }
+      return res;
+    }
+
+    private static ClickableSpan[] findClickableSpan(
+        TextView widget, Spannable buffer, MotionEvent event) {
+      int x = (int) event.getX();
+      int y = (int) event.getY();
+
+      x -= widget.getTotalPaddingLeft();
+      y -= widget.getTotalPaddingTop();
+
+      x += widget.getScrollX();
+      y += widget.getScrollY();
+
+      Layout layout = widget.getLayout();
+      int line = layout.getLineForVertical(y);
+      int off = layout.getOffsetForHorizontal(line, x);
+
+      return buffer.getSpans(off, off, ClickableSpan.class);
+    }
+
+    public static MovementMethod getInstance(ColorStateList colorStateList) {
+      if (movementMethod == null) {
+        movementMethod = new ColorStateLinkMovementMethod(colorStateList);
+      }
+      return movementMethod;
+    }
+
+    private ColorStateLinkMovementMethod(ColorStateList colorStateList) {
+      final int pressedColor
+          = colorStateList.getColorForState(new int[]{android.R.attr.state_pressed},
+          colorStateList.getDefaultColor());
+      pressedBackground = new BackgroundColorSpan(pressedColor);
+    }
+  }
+}

--- a/app/src/main/java/com/freshdigitable/udonroad/MainActivity.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/MainActivity.java
@@ -248,6 +248,9 @@ public class MainActivity extends AppCompatActivity
   private StatusDetailFragment statusDetail;
 
   private void showStatusDetail(long status) {
+    if (statusDetail != null && statusDetail.isVisible()) {
+      return;
+    }
     statusDetail = StatusDetailFragment.getInstance(status);
     getSupportFragmentManager().beginTransaction()
         .hide(tlFragment)
@@ -255,9 +258,6 @@ public class MainActivity extends AppCompatActivity
         .setTransition(FragmentTransaction.TRANSIT_FRAGMENT_OPEN)
         .commit();
     tlFragment.stopScroll();
-    if (tlFragment.isTweetSelected()) {
-      binding.ffab.hide();
-    }
   }
 
   private boolean hideStatusDetail() {
@@ -271,9 +271,6 @@ public class MainActivity extends AppCompatActivity
         .commit();
     statusDetail = null;
     tlFragment.startScroll();
-    if (tlFragment.isTweetSelected()) {
-      binding.ffab.show();
-    }
     return true;
   }
 

--- a/app/src/main/java/com/freshdigitable/udonroad/SpannableStringUtil.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/SpannableStringUtil.java
@@ -17,17 +17,12 @@
 package com.freshdigitable.udonroad;
 
 import android.support.annotation.Nullable;
-import android.text.Selection;
-import android.text.SpanWatcher;
-import android.text.Spannable;
 import android.text.SpannableStringBuilder;
 import android.text.Spanned;
-import android.text.TextPaint;
 import android.text.TextUtils;
 import android.text.style.ClickableSpan;
 import android.text.style.URLSpan;
 import android.view.View;
-import android.widget.TextView;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -177,7 +172,7 @@ class SpannableStringUtil {
     final String displayingText;
 
     SpanningInfo(@Nullable ClickableSpan span, int start, int end, @Nullable String displayingText) {
-      this.span = span != null ? new WatchedClickableSpan(span) : null;
+      this.span = span;
       this.start = start;
       this.end = end;
       this.displayingText = displayingText;
@@ -189,51 +184,6 @@ class SpannableStringUtil {
 
     boolean isReplacing() {
       return displayingText != null;
-    }
-  }
-
-  private static class WatchedClickableSpan extends ClickableSpan implements SpanWatcher {
-    final String TAG = WatchedClickableSpan.class.getSimpleName();
-    final ClickableSpan clickableSpan;
-    private boolean selected = false;
-
-    WatchedClickableSpan(ClickableSpan clickableSpan) {
-      this.clickableSpan = clickableSpan;
-    }
-
-    @Override
-    public void onSpanAdded(Spannable text, Object what, int start, int end) {
-      // dependent internal logic of LinkMovementMethod.onTouchEvent()
-      if (what == Selection.SELECTION_START) {
-        selected = true;
-      }
-    }
-
-    @Override
-    public void onSpanRemoved(Spannable text, Object what, int start, int end) {
-      // dependent internal logic of LinkMovementMethod.onTouchEvent()
-      if (what == Selection.SELECTION_START) {
-        selected = false;
-      }
-    }
-
-    @Override
-    public void onClick(View widget) {
-      // dependent internal logic of LinkMovementMethod.onTouchEvent()
-      clickableSpan.onClick(widget);
-      if (widget instanceof TextView) {
-        Selection.removeSelection(((Spannable) ((TextView) widget).getText()));
-      }
-    }
-
-    @Override
-    public void updateDrawState(TextPaint ds) {
-      ds.bgColor = selected ? 0xffeeeeee : 0;  // XXX
-      super.updateDrawState(ds);
-    }
-
-    @Override
-    public void onSpanChanged(Spannable text, Object what, int ostart, int oend, int nstart, int nend) {
     }
   }
 }

--- a/app/src/main/java/com/freshdigitable/udonroad/StatusDetailFragment.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/StatusDetailFragment.java
@@ -116,6 +116,13 @@ public class StatusDetailFragment extends Fragment {
 
     final ImageView icon = statusView.getIcon();
     final OnUserIconClickedListener userIconClickedListener = createUserIconClickedListener();
+    final User rtUser = status.getUser();
+    statusView.getRtUser().setOnClickListener(new View.OnClickListener() {
+      @Override
+      public void onClick(View v) {
+        userIconClickedListener.onUserIconClicked(v, rtUser);
+      }
+    });
     icon.setOnClickListener(new View.OnClickListener() {
       @Override
       public void onClick(View view) {
@@ -271,6 +278,7 @@ public class StatusDetailFragment extends Fragment {
   @Override
   public void onStop() {
     super.onStop();
+    binding.statusView.getRtUser().setOnClickListener(null);
     binding.statusView.getIcon().setOnClickListener(null);
     binding.statusView.getUserName().setOnClickListener(null);
     binding.statusView.getMediaContainer().setOnMediaClickListener(null);

--- a/app/src/main/java/com/freshdigitable/udonroad/StatusDetailFragment.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/StatusDetailFragment.java
@@ -110,11 +110,11 @@ public class StatusDetailFragment extends Fragment {
 
     final ImageView icon = statusView.getIcon();
     final OnUserIconClickedListener userIconClickedListener = createUserIconClickedListener();
-    final User rtUser = status.getUser();
+    final long rtUserId = status.getUser().getId();
     statusView.getRtUser().setOnClickListener(new View.OnClickListener() {
       @Override
       public void onClick(View v) {
-        userIconClickedListener.onUserIconClicked(v, rtUser);
+        UserInfoActivity.start(v.getContext(), rtUserId);
       }
     });
     icon.setOnClickListener(new View.OnClickListener() {

--- a/app/src/main/java/com/freshdigitable/udonroad/StatusDetailFragment.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/StatusDetailFragment.java
@@ -20,17 +20,13 @@ import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.databinding.DataBindingUtil;
-import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.os.Bundle;
-import android.support.annotation.ColorRes;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentActivity;
 import android.support.v4.app.FragmentTransaction;
-import android.support.v4.content.ContextCompat;
-import android.support.v4.graphics.drawable.DrawableCompat;
 import android.text.TextUtils;
 import android.util.Log;
 import android.view.LayoutInflater;
@@ -43,8 +39,6 @@ import android.widget.Toast;
 
 import com.freshdigitable.udonroad.MediaContainer.OnMediaClickListener;
 import com.freshdigitable.udonroad.StatusViewBase.OnUserIconClickedListener;
-import com.freshdigitable.udonroad.TweetInputFragment.TweetSendable;
-import com.freshdigitable.udonroad.TweetInputFragment.TweetType;
 import com.freshdigitable.udonroad.databinding.FragmentStatusDetailBinding;
 import com.freshdigitable.udonroad.datastore.TypedCache;
 import com.freshdigitable.udonroad.module.InjectionUtil;
@@ -142,54 +136,12 @@ public class StatusDetailFragment extends Fragment {
       }
     });
 
-    setTintList(binding.sdFav.getDrawable(), R.color.selector_fav_icon);
-    binding.sdFav.setOnClickListener(new View.OnClickListener() {
-      @Override
-      public void onClick(View view) {
-        if (status.isFavorited()) {
-          statusRequestWorker.destroyFavorite(statusId);
-        } else {
-          statusRequestWorker.createFavorite(statusId);
-        }
-      }
-    });
-    setTintList(binding.sdRetweet.getDrawable(), R.color.selector_rt_icon);
-    binding.sdRetweet.setOnClickListener(new View.OnClickListener() {
-      @Override
-      public void onClick(View view) {
-        if (status.isRetweeted()) {
-          statusRequestWorker.destroyRetweet(statusId);
-        } else {
-          statusRequestWorker.retweetStatus(statusId);
-        }
-      }
-    });
-    DrawableCompat.setTint(binding.sdReply.getDrawable(),
-        ContextCompat.getColor(getContext(), R.color.twitter_action_normal));
-    binding.sdReply.setOnClickListener(new View.OnClickListener() {
-      @Override
-      public void onClick(View view) {
-        setupInput(TweetInputFragment.TYPE_REPLY);
-      }
-    });
-    setTintList(binding.sdQuote.getDrawable(), R.color.twitter_action_normal);
-    binding.sdQuote.setOnClickListener(new View.OnClickListener() {
-      @Override
-      public void onClick(View view) {
-        setupInput(TweetInputFragment.TYPE_QUOTE);
-      }
-    });
-
     binding.statusView.bindStatus(status);
-    binding.sdFav.setActivated(status.isFavorited());
-    binding.sdRetweet.setActivated(status.isRetweeted());
     subscription = statusCache.observeById(statusId)
         .subscribe(new Action1<Status>() {
           @Override
           public void call(Status status) {
             binding.statusView.update(status);
-            binding.sdFav.setActivated(status.isFavorited());
-            binding.sdRetweet.setActivated(status.isRetweeted());
           }
         });
 
@@ -260,21 +212,6 @@ public class StatusDetailFragment extends Fragment {
         && !TextUtils.isEmpty(twitterCard.getUrl());
   }
 
-  private void setTintList(Drawable drawable, @ColorRes int color) {
-    DrawableCompat.setTintList(drawable,
-        ContextCompat.getColorStateList(getContext(), color));
-  }
-
-  private void setupInput(@TweetType int type) {
-    final FragmentActivity activity = getActivity();
-    final long statusId = getStatusId();
-    if (activity instanceof TweetSendable) {
-      ((TweetSendable) activity).setupInput(type, statusId);
-    } else {
-      ReplyActivity.start(activity, statusId, type, null);
-    }
-  }
-
   @Override
   public void onStop() {
     super.onStop();
@@ -284,10 +221,6 @@ public class StatusDetailFragment extends Fragment {
     binding.statusView.getMediaContainer().setOnMediaClickListener(null);
     binding.statusView.reset();
     binding.sdTwitterCard.setOnClickListener(null);
-    binding.sdFav.setOnClickListener(null);
-    binding.sdRetweet.setOnClickListener(null);
-    binding.sdReply.setOnClickListener(null);
-    binding.sdQuote.setOnClickListener(null);
     if (subscription != null && !subscription.isUnsubscribed()) {
       subscription.unsubscribe();
     }
@@ -301,8 +234,6 @@ public class StatusDetailFragment extends Fragment {
   public void onDetach() {
     super.onDetach();
     binding.sdTwitterCard.setVisibility(View.GONE);
-    DrawableCompat.setTintList(binding.sdFav.getDrawable(), null);
-    DrawableCompat.setTintList(binding.sdRetweet.getDrawable(), null);
   }
 
   private OnUserIconClickedListener createUserIconClickedListener() {

--- a/app/src/main/java/com/freshdigitable/udonroad/StatusDetailView.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/StatusDetailView.java
@@ -17,11 +17,14 @@
 package com.freshdigitable.udonroad;
 
 import android.content.Context;
+import android.text.format.DateUtils;
 import android.text.method.LinkMovementMethod;
 import android.util.AttributeSet;
 import android.view.View;
 import android.widget.ImageView;
 import android.widget.TextView;
+
+import java.util.Date;
 
 import twitter4j.Status;
 
@@ -55,6 +58,12 @@ public class StatusDetailView extends FullStatusView {
     mediaContainer = (MediaContainer) v.findViewById(R.id.d_image_group);
     rtUser = (RetweetUserView) v.findViewById(R.id.d_rt_user);
     quotedStatus = (QuotedStatusView) v.findViewById(R.id.d_quoted);
+  }
+
+  @Override
+  protected void bindCreatedAt(Date tweetedDate) {
+    createdAt.setText(DateUtils.formatDateTime(getContext(), tweetedDate.getTime(),
+        DateUtils.FORMAT_SHOW_YEAR | DateUtils.FORMAT_SHOW_DATE | DateUtils.FORMAT_SHOW_TIME));
   }
 
   @Override

--- a/app/src/main/java/com/freshdigitable/udonroad/StatusDetailView.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/StatusDetailView.java
@@ -18,7 +18,6 @@ package com.freshdigitable.udonroad;
 
 import android.content.Context;
 import android.text.format.DateUtils;
-import android.text.method.LinkMovementMethod;
 import android.util.AttributeSet;
 import android.view.View;
 import android.widget.ImageView;
@@ -50,8 +49,7 @@ public class StatusDetailView extends FullStatusView {
     createdAt = (TextView) v.findViewById(R.id.d_create_at);
     icon = (ImageView) v.findViewById(R.id.d_icon);
     names = (CombinedScreenNameTextView) v.findViewById(R.id.d_names);
-    tweet = (TextView) v.findViewById(R.id.d_tweet);
-    tweet.setMovementMethod(LinkMovementMethod.getInstance());
+    tweet = (LinkableTextView) v.findViewById(R.id.d_tweet);
     clientName = (TextView) v.findViewById(R.id.d_via);
     rtCount = (IconAttachedCounterView) v.findViewById(R.id.d_rtcount);
     favCount = (IconAttachedCounterView) v.findViewById(R.id.d_favcount);

--- a/app/src/main/res/color/selector_link_text.xml
+++ b/app/src/main/res/color/selector_link_text.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2017. Matsuda, Akihit (akihito104)
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_pressed="true"
+        android:color="@color/twitter_action_normal_transparent"/>
+    <item android:color="@android:color/transparent"/>
+</selector>

--- a/app/src/main/res/layout/fragment_status_detail.xml
+++ b/app/src/main/res/layout/fragment_status_detail.xml
@@ -16,7 +16,6 @@
   -->
 <layout
     xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     >
     <ScrollView
@@ -42,52 +41,6 @@
                 android:visibility="gone"
                 tools:visibility="visible"
                 />
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="36dp"
-                android:orientation="horizontal"
-                >
-                <ImageView
-                    android:id="@+id/sd_fav"
-                    android:layout_width="0dp"
-                    android:layout_height="match_parent"
-                    android:layout_weight="1"
-                    android:layout_marginStart="@dimen/grid_margin_detail"
-                    android:layout_marginEnd="@dimen/grid_margin_detail"
-                    app:srcCompat="@drawable/ic_like"
-                    android:clickable="true"
-                    />
-                <ImageView
-                    android:id="@+id/sd_retweet"
-                    android:layout_width="0dp"
-                    android:layout_height="match_parent"
-                    android:layout_weight="1"
-                    android:layout_marginStart="@dimen/grid_margin_detail"
-                    android:layout_marginEnd="@dimen/grid_margin_detail"
-                    app:srcCompat="@drawable/ic_retweet"
-                    android:clickable="true"
-                    />
-                <ImageView
-                    android:id="@+id/sd_reply"
-                    android:layout_width="0dp"
-                    android:layout_height="match_parent"
-                    android:layout_weight="1"
-                    android:layout_marginStart="@dimen/grid_margin_detail"
-                    android:layout_marginEnd="@dimen/grid_margin_detail"
-                    app:srcCompat="@drawable/ic_reply"
-                    android:clickable="true"
-                    />
-                <ImageView
-                    android:id="@+id/sd_quote"
-                    android:layout_width="0dp"
-                    android:layout_height="match_parent"
-                    android:layout_weight="1"
-                    android:layout_marginStart="@dimen/grid_margin_detail"
-                    android:layout_marginEnd="@dimen/grid_margin_detail"
-                    app:srcCompat="@drawable/ic_quote"
-                    android:clickable="true"
-                    />
-            </LinearLayout>
         </LinearLayout>
     </ScrollView>
 </layout>

--- a/app/src/main/res/layout/view_status_detail.xml
+++ b/app/src/main/res/layout/view_status_detail.xml
@@ -47,45 +47,26 @@
         android:id="@+id/d_icon"
         android:layout_width="@dimen/tweet_user_icon"
         android:layout_height="@dimen/tweet_user_icon"
+        android:layout_marginRight="@dimen/grid_margin_detail"
+        android:layout_marginBottom="@dimen/grid_margin_detail"
         android:layout_below="@+id/d_rt_user"
         android:layout_alignParentLeft="true"
         android:layout_alignParentStart="true"
         android:contentDescription="@string/desc_icon"
-        android:layout_marginRight="@dimen/grid_margin"
         />
 
-    <LinearLayout
-        android:id="@+id/d_names_and_time"
+    <com.freshdigitable.udonroad.CombinedScreenNameTextView
+        android:id="@+id/d_names"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_alignTop="@+id/d_icon"
         android:layout_toRightOf="@id/d_icon"
         android:layout_alignParentEnd="true"
-        >
-        <com.freshdigitable.udonroad.CombinedScreenNameTextView
-            android:id="@+id/d_names"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:layout_marginRight="@dimen/grid_margin"
-            android:textSize="@dimen/tweet_detail_small_size"
-            android:lines="2"
-            android:ellipsize="end"
-            tools:text="name\n\@screenName"
-            />
-
-        <TextView
-            android:id="@+id/d_create_at"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_weight="0"
-            android:gravity="end"
-            android:textAppearance="?android:attr/textAppearanceSmall"
-            android:textSize="@dimen/tweet_small_fontsize"
-            android:lines="1"
-            tools:text="CreatedTime"
-            />
-    </LinearLayout>
+        android:textSize="@dimen/tweet_detail_small_size"
+        android:lines="2"
+        android:ellipsize="end"
+        tools:text="name\n\@screenName"
+        />
 
     <TextView
         android:id="@+id/d_tweet"
@@ -93,9 +74,38 @@
         android:layout_height="wrap_content"
         android:layout_below="@+id/d_icon"
         android:layout_alignParentStart="true"
-        android:layout_marginTop="@dimen/grid_margin"
+        android:layout_marginBottom="@dimen/grid_margin_detail"
         android:textSize="@dimen/tweet_detail_size"
+        android:lineSpacingExtra="@dimen/grid_margin"
         tools:text="Tweet"
+        />
+
+    <com.freshdigitable.udonroad.MediaContainer
+        android:id="@+id/d_image_group"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/tweet_user_icon"
+        android:layout_marginBottom="@dimen/grid_margin_detail"
+        android:layout_below="@id/d_tweet"
+        android:layout_alignParentStart="true"
+        android:layout_alignParentEnd="true"
+        android:layout_alignParentRight="true"
+        android:orientation="horizontal"
+        android:visibility="gone"
+        tools:visibility="visible"
+        app:thumbCount="4"
+        />
+
+    <TextView
+        android:id="@+id/d_create_at"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="@dimen/grid_margin_detail"
+        android:layout_below="@id/d_image_group"
+        android:gravity="end"
+        android:textAppearance="?android:attr/textAppearanceSmall"
+        android:textSize="@dimen/tweet_detail_small_size"
+        android:lines="1"
+        tools:text="CreatedTime"
         />
 
     <com.freshdigitable.udonroad.IconAttachedCounterView
@@ -133,7 +143,8 @@
         android:id="@+id/d_via"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_below="@+id/d_image_group"
+        android:layout_marginBottom="@dimen/grid_margin_detail"
+        android:layout_below="@+id/d_create_at"
         android:layout_alignParentRight="true"
         android:layout_alignParentEnd="true"
         android:layout_toRightOf="@+id/d_favcount"
@@ -143,22 +154,6 @@
         android:ellipsize="end"
         android:textAppearance="?android:attr/textAppearanceSmall"
         tools:text="via clientname"
-        />
-
-    <com.freshdigitable.udonroad.MediaContainer
-        android:id="@+id/d_image_group"
-        android:layout_width="match_parent"
-        android:layout_height="@dimen/tweet_user_icon"
-        android:layout_marginTop="@dimen/grid_margin"
-        android:layout_marginBottom="@dimen/grid_margin"
-        android:layout_below="@id/d_tweet"
-        android:layout_alignParentStart="true"
-        android:layout_alignParentEnd="true"
-        android:layout_alignParentRight="true"
-        android:orientation="horizontal"
-        android:visibility="gone"
-        tools:visibility="visible"
-        app:thumbCount="4"
         />
 
     <com.freshdigitable.udonroad.QuotedStatusView

--- a/app/src/main/res/layout/view_status_detail.xml
+++ b/app/src/main/res/layout/view_status_detail.xml
@@ -78,7 +78,7 @@
         app:srcCompat="@drawable/ic_twitter_bird"
         />
 
-    <TextView
+    <com.freshdigitable.udonroad.LinkableTextView
         android:id="@+id/d_tweet"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/app/src/main/res/layout/view_status_detail.xml
+++ b/app/src/main/res/layout/view_status_detail.xml
@@ -61,11 +61,21 @@
         android:layout_height="wrap_content"
         android:layout_alignTop="@+id/d_icon"
         android:layout_toRightOf="@id/d_icon"
-        android:layout_alignParentEnd="true"
         android:textSize="@dimen/tweet_detail_small_size"
         android:lines="2"
         android:ellipsize="end"
         tools:text="name\n\@screenName"
+        />
+
+    <android.support.v7.widget.AppCompatImageView
+        android:id="@+id/d_twitter_bird"
+        android:layout_width="32dp"
+        android:layout_height="32dp"
+        android:layout_alignTop="@id/d_names"
+        android:layout_alignBottom="@id/d_names"
+        android:layout_alignParentRight="true"
+        android:tint="@color/twitter_primary"
+        app:srcCompat="@drawable/ic_twitter_bird"
         />
 
     <TextView


### PR DESCRIPTION
refs: #175 

- [x] twitter birdを表示する
- [x] ツイート日時を絶対時刻表示にする
- [x] リンクを押しやすくするためにツイートの行間を拡げる
- [x] リンクを押した時に反応をかえす #107 
- [x] RT/favのカウントとメニューの並び順を揃える -> buttonを削除してFFABで代替
