### PR TITLE
[WIP] データ更新イベントを通知する処理の修正

### DIFF
--- a/app/src/androidTest/java/com/freshdigitable/udonroad/TimelineInstTestBase.java
+++ b/app/src/androidTest/java/com/freshdigitable/udonroad/TimelineInstTestBase.java
@@ -234,15 +234,11 @@ public abstract class TimelineInstTestBase {
   }
 
   private static void clearCache(BaseCache cache) {
-    cache.open();
-    cache.clear();
-    cache.close();
+    cache.drop();
   }
 
   private static void clearCache(SortedCache cache, String name) {
-    cache.open(name);
-    cache.clear();
-    cache.close();
+    cache.drop(name);
   }
 
   private static void checkAllRealmInstanceCleared() {  // XXX
@@ -254,8 +250,8 @@ public abstract class TimelineInstTestBase {
 
   private static void checkRealmInstanceCount(String name, int count) {  // XXX
     final RealmConfiguration conf = new RealmConfiguration.Builder().name(name).build();
-    assertThat(Realm.getLocalInstanceCount(conf), is(count));
-    assertThat(Realm.getGlobalInstanceCount(conf), is(count));
+    assertThat("local instance count: " + name, Realm.getLocalInstanceCount(conf), is(count));
+    assertThat("global instance count: " + name, Realm.getGlobalInstanceCount(conf), is(count));
   }
 
   private StreamIdlingResource streamIdlingResource;

--- a/app/src/androidTest/java/com/freshdigitable/udonroad/TimelineInstTestBase.java
+++ b/app/src/androidTest/java/com/freshdigitable/udonroad/TimelineInstTestBase.java
@@ -44,7 +44,6 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import javax.inject.Inject;
@@ -173,11 +172,11 @@ public abstract class TimelineInstTestBase {
     clearCache(statusCache);
     clearCache(configStore);
     clearCache(appSettings);
-    clearCache(homeTLStore, "home");
-    clearCache(userHomeTLStore, "user_home");
-    clearCache(userFavsTLStore, "user_favs");
-    clearCache(userFollowers, "user_followers");
-    clearCache(userFriends, "user_friends");
+    clearCache(homeTLStore, StoreType.HOME.storeName);
+    clearCache(userHomeTLStore, StoreType.USER_HOME.storeName);
+    clearCache(userFavsTLStore, StoreType.USER_FAV.storeName);
+    clearCache(userFollowers, StoreType.USER_FOLLOWER.storeName);
+    clearCache(userFriends, StoreType.USER_FRIEND.storeName);
     checkAllRealmInstanceCleared();
   }
 
@@ -247,10 +246,10 @@ public abstract class TimelineInstTestBase {
   }
 
   private static void checkAllRealmInstanceCleared() {  // XXX
-    for (String name : Arrays.asList("cache", "config", "appSettings", "home",
-        "user_home", "user_favs", "user_followers", "user_friends")) {
-      checkRealmInstanceCount(name, 0);
+    for (StoreType t : StoreType.values()) {
+      checkRealmInstanceCount(t.storeName, 0);
     }
+    checkRealmInstanceCount("cache", 0);
   }
 
   private static void checkRealmInstanceCount(String name, int count) {  // XXX

--- a/app/src/main/java/com/freshdigitable/udonroad/FabHandleable.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/FabHandleable.java
@@ -18,6 +18,8 @@ package com.freshdigitable.udonroad;
 
 import android.support.annotation.IdRes;
 
+import com.freshdigitable.udonroad.ffab.IndicatableFFAB.OnIffabItemSelectedListener;
+
 /**
  * FabHandleable is a interface to be implemented by Activity which FAB manages.
  *
@@ -29,4 +31,8 @@ public interface FabHandleable {
   void hideFab();
 
   void setCheckedFabMenuItem(@IdRes int itemId, boolean checked);
+
+  void addOnItemSelectedListener(OnIffabItemSelectedListener listener);
+
+  void removeOnItemSelectedListener(OnIffabItemSelectedListener listener);
 }

--- a/app/src/main/java/com/freshdigitable/udonroad/MainActivity.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/MainActivity.java
@@ -65,6 +65,7 @@ import twitter4j.Status;
 import twitter4j.User;
 import twitter4j.auth.AccessToken;
 
+import static com.freshdigitable.udonroad.StoreType.HOME;
 import static com.freshdigitable.udonroad.TweetInputFragment.TYPE_DEFAULT;
 import static com.freshdigitable.udonroad.TweetInputFragment.TYPE_QUOTE;
 import static com.freshdigitable.udonroad.TweetInputFragment.TYPE_REPLY;
@@ -84,7 +85,6 @@ public class MainActivity extends AppCompatActivity
 
   @Inject
   TwitterApi twitterApi;
-  private SortedCache<Status> homeTimeline;
   @Inject
   StatusRequestWorker<SortedCache<Status>> statusRequestWorker;
   @Inject
@@ -123,8 +123,8 @@ public class MainActivity extends AppCompatActivity
   }
 
   private void setupHomeTimeline() {
-    statusRequestWorker.open(StoreType.HOME.storeName);
-    homeTimeline = statusRequestWorker.getCache();
+    statusRequestWorker.open(HOME.storeName);
+    SortedCache<Status> homeTimeline = statusRequestWorker.getCache();
     homeTimeline.clearPool();
 
     tlFragment = new TimelineFragment<>();
@@ -210,7 +210,7 @@ public class MainActivity extends AppCompatActivity
   @Override
   protected void onStart() {
     super.onStart();
-    userStream.connect(homeTimeline);
+    userStream.connect(StoreType.HOME.storeName);
 
     binding.mainToolbar.setTitle("Home");
     setSupportActionBar(binding.mainToolbar);

--- a/app/src/main/java/com/freshdigitable/udonroad/MainActivity.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/MainActivity.java
@@ -117,25 +117,6 @@ public class MainActivity extends AppCompatActivity
 
     getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
 
-    binding.navDrawer.setNavigationItemSelectedListener(item -> {
-      int itemId = item.getItemId();
-      if (itemId == R.id.menu_home) {
-        Log.d(TAG, "home is selected");
-        binding.navDrawerLayout.closeDrawer(binding.navDrawer);
-      } else if (itemId == R.id.menu_mention) {
-        Log.d(TAG, "mention is selected");
-        binding.navDrawerLayout.closeDrawer(binding.navDrawer);
-      } else if (itemId == R.id.menu_fav) {
-        Log.d(TAG, "fav is selected");
-        binding.navDrawerLayout.closeDrawer(binding.navDrawer);
-      } else if (itemId == R.id.menu_license) {
-        startActivity(new Intent(getApplicationContext(), LicenseActivity.class));
-        binding.navDrawerLayout.closeDrawer(binding.navDrawer);
-      }
-      return false;
-    });
-
-    binding.ffab.hide();
     setupHomeTimeline();
     setupTweetInputView();
     setupNavigationDrawer();
@@ -160,7 +141,24 @@ public class MainActivity extends AppCompatActivity
   private void setupNavigationDrawer() {
     attachToolbar(binding.mainToolbar);
     subscription = configRequestWorker.getAuthenticatedUser()
-        .subscribe(this::setupNavigationDrawer);
+        .subscribe(this::setupNavigationDrawerHeader);
+    binding.navDrawer.setNavigationItemSelectedListener(item -> {
+      int itemId = item.getItemId();
+      if (itemId == R.id.menu_home) {
+        Log.d(TAG, "home is selected");
+        binding.navDrawerLayout.closeDrawer(binding.navDrawer);
+      } else if (itemId == R.id.menu_mention) {
+        Log.d(TAG, "mention is selected");
+        binding.navDrawerLayout.closeDrawer(binding.navDrawer);
+      } else if (itemId == R.id.menu_fav) {
+        Log.d(TAG, "fav is selected");
+        binding.navDrawerLayout.closeDrawer(binding.navDrawer);
+      } else if (itemId == R.id.menu_license) {
+        startActivity(new Intent(getApplicationContext(), LicenseActivity.class));
+        binding.navDrawerLayout.closeDrawer(binding.navDrawer);
+      }
+      return false;
+    });
   }
 
   private void attachToolbar(Toolbar toolbar) {
@@ -183,7 +181,7 @@ public class MainActivity extends AppCompatActivity
     actionBarDrawerToggle.syncState();
   }
 
-  private void setupNavigationDrawer(@Nullable User user) {
+  private void setupNavigationDrawerHeader(@Nullable User user) {
     if (user == null) {
       return;
     }

--- a/app/src/main/java/com/freshdigitable/udonroad/MainActivity.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/MainActivity.java
@@ -123,7 +123,7 @@ public class MainActivity extends AppCompatActivity
   }
 
   private void setupHomeTimeline() {
-    statusRequestWorker.open("home");
+    statusRequestWorker.open(StoreType.HOME.storeName);
     homeTimeline = statusRequestWorker.getCache();
     homeTimeline.clearPool();
 
@@ -339,7 +339,7 @@ public class MainActivity extends AppCompatActivity
     if (conversationRequestWorker.isOpened()) {
       conversationRequestWorker.close();
     }
-    final String name = "conv_" + Long.toString(statusId);
+    final String name = StoreType.CONVERSATION.prefix() + Long.toString(statusId);
     conversationRequestWorker.open(name);
 
     final TimelineFragment<Status> conversationFragment = new TimelineFragment<>();

--- a/app/src/main/java/com/freshdigitable/udonroad/MainActivity.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/MainActivity.java
@@ -241,6 +241,7 @@ public class MainActivity extends AppCompatActivity
       iffabItemSelectedListeners.clear();
       binding.ffab.clear();
       binding.navDrawer.setNavigationItemSelectedListener(null);
+      configRequestWorker.shrink();
       configRequestWorker.close();
       appSettings.close();
       userFeedback.unsubscribe();

--- a/app/src/main/java/com/freshdigitable/udonroad/StoreName.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/StoreName.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.freshdigitable.udonroad.datastore;
+package com.freshdigitable.udonroad;
 
 /**
  * Created by akihit on 2017/03/21.
@@ -30,9 +30,9 @@ public enum StoreName {
   CONFIG("config"),
   APP_SETTINGS("appSettings");
 
-  private final String cacheName;
+  final String prefix;
 
-  StoreName(String cacheName) {
-    this.cacheName = cacheName;
+  StoreName(String prefix) {
+    this.prefix = prefix;
   }
 }

--- a/app/src/main/java/com/freshdigitable/udonroad/StoreType.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/StoreType.java
@@ -16,6 +16,8 @@
 
 package com.freshdigitable.udonroad;
 
+import java.util.Arrays;
+
 /**
  * Created by akihit on 2017/03/21.
  */
@@ -38,5 +40,23 @@ public enum StoreType {
 
   public String prefix() {
     return storeName + "_";
+  }
+
+  public boolean isForStatus() {
+    for (StoreType type : Arrays.asList(HOME, USER_HOME, USER_FAV, CONVERSATION)) {
+      if (this == type) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  public boolean isForUser() {
+    for (StoreType type : Arrays.asList(USER_FOLLOWER, USER_FRIEND)) {
+      if (this == type) {
+        return true;
+      }
+    }
+    return false;
   }
 }

--- a/app/src/main/java/com/freshdigitable/udonroad/StoreType.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/StoreType.java
@@ -20,7 +20,7 @@ package com.freshdigitable.udonroad;
  * Created by akihit on 2017/03/21.
  */
 
-public enum StoreName {
+public enum StoreType {
   HOME("home"),
   USER_HOME("user_home"),
   USER_FAV("user_favs"),
@@ -30,9 +30,13 @@ public enum StoreName {
   CONFIG("config"),
   APP_SETTINGS("appSettings");
 
-  final String prefix;
+  public final String storeName;
 
-  StoreName(String prefix) {
-    this.prefix = prefix;
+  StoreType(String name) {
+    this.storeName = name;
+  }
+
+  public String prefix() {
+    return storeName + "_";
   }
 }

--- a/app/src/main/java/com/freshdigitable/udonroad/TimelineFragment.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/TimelineFragment.java
@@ -327,6 +327,7 @@ public abstract class TimelineFragment<T> extends Fragment {
     binding.timeline.setAdapter(null);
     updateEventSubscription.unsubscribe();
     requestWorker.close();
+    requestWorker.drop();
     tlAdapter = null;
   }
 

--- a/app/src/main/java/com/freshdigitable/udonroad/UserInfoActivity.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/UserInfoActivity.java
@@ -42,7 +42,11 @@ import com.freshdigitable.udonroad.TweetInputFragment.TweetSendable;
 import com.freshdigitable.udonroad.UserInfoPagerFragment.UserPageInfo;
 import com.freshdigitable.udonroad.databinding.ActivityUserInfoBinding;
 import com.freshdigitable.udonroad.datastore.TypedCache;
+import com.freshdigitable.udonroad.ffab.IndicatableFFAB.OnIffabItemSelectedListener;
 import com.freshdigitable.udonroad.module.InjectionUtil;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import javax.inject.Inject;
 
@@ -173,6 +177,12 @@ public class UserInfoActivity extends AppCompatActivity
   }
 
   @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    iffabItemSelectedListeners.clear();
+  }
+
+  @Override
   public boolean onOptionsItemSelected(MenuItem item) {
     final int itemId = item.getItemId();
     if (itemId == R.id.action_cancel) {
@@ -276,21 +286,16 @@ public class UserInfoActivity extends AppCompatActivity
   private void setupActionMap() {
     binding.ffab.setOnIffabItemSelectedListener(item -> {
       final int itemId = item.getItemId();
-      if (itemId == R.id.iffabMenu_main_fav) {
-        viewPager.createFavorite();
-      } else if (itemId == R.id.iffabMenu_main_rt) {
-        viewPager.retweetStatus();
-      } else if (itemId == R.id.iffabMenu_main_favRt) {
-        viewPager.createFavAndRetweet();
-      } else if (itemId == R.id.iffabMenu_main_reply) {
-        final long selectedTweetId = viewPager.getCurrentSelectedStatusId();
+      final long selectedTweetId = viewPager.getCurrentSelectedStatusId();
+      if (itemId == R.id.iffabMenu_main_reply) {
         showTwitterInputView(TYPE_REPLY, selectedTweetId);
       } else if (itemId == R.id.iffabMenu_main_quote) {
-        final long selectedTweetId = viewPager.getCurrentSelectedStatusId();
         showTwitterInputView(TYPE_QUOTE, selectedTweetId);
       } else if (itemId == R.id.iffabMenu_main_detail) {
-        final long statusId = viewPager.getCurrentSelectedStatusId();
-        showStatusDetail(statusId);
+        showStatusDetail(selectedTweetId);
+      }
+      for (OnIffabItemSelectedListener l : iffabItemSelectedListeners) {
+        l.onItemSelected(item);
       }
     });
   }
@@ -330,5 +335,17 @@ public class UserInfoActivity extends AppCompatActivity
   @Override
   public void setCheckedFabMenuItem(@IdRes int itemId, boolean checked) {
     binding.ffab.getMenu().findItem(itemId).setChecked(checked);
+  }
+
+  private List<OnIffabItemSelectedListener> iffabItemSelectedListeners = new ArrayList<>();
+
+  @Override
+  public void addOnItemSelectedListener(OnIffabItemSelectedListener listener) {
+    iffabItemSelectedListeners.add(listener);
+  }
+
+  @Override
+  public void removeOnItemSelectedListener(OnIffabItemSelectedListener listener) {
+    iffabItemSelectedListeners.remove(listener);
   }
 }

--- a/app/src/main/java/com/freshdigitable/udonroad/UserInfoPagerFragment.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/UserInfoPagerFragment.java
@@ -339,25 +339,25 @@ public class UserInfoPagerFragment extends Fragment {
   }
 
   enum UserPageInfo {
-    TWEET(REQUEST_CODE_USER_HOME, "user_home") {
+    TWEET(REQUEST_CODE_USER_HOME, StoreType.USER_HOME) {
       @Override
       public String createTitle(User user) {
         return name() + "\n" + user.getStatusesCount();
       }
     },
-    FRIEND(REQUEST_CODE_USER_FRIENDS, "user_friends") {
+    FRIEND(REQUEST_CODE_USER_FRIENDS, StoreType.USER_FRIEND) {
       @Override
       public String createTitle(User user) {
         return name() + "\n" + user.getFriendsCount();
       }
     },
-    FOLLOWER(REQUEST_CODE_USER_FOLLOWERS, "user_followers") {
+    FOLLOWER(REQUEST_CODE_USER_FOLLOWERS, StoreType.USER_FOLLOWER) {
       @Override
       public String createTitle(User user) {
         return name() + "\n" + user.getFollowersCount();
       }
     },
-    FAV(REQUEST_CODE_USER_FAVS, "user_favs") {
+    FAV(REQUEST_CODE_USER_FAVS, StoreType.USER_FAV) {
       @Override
       public String createTitle(User user) {
         return name() + "\n" + user.getFavouritesCount();
@@ -365,16 +365,16 @@ public class UserInfoPagerFragment extends Fragment {
     },;
 
     final @RequestCodeEnum int requestCode;
-    final String cacheName;
+    final StoreType storeType;
 
-    UserPageInfo(@RequestCodeEnum int requestCode, String cacheName) {
+    UserPageInfo(@RequestCodeEnum int requestCode, StoreType type) {
       this.requestCode = requestCode;
-      this.cacheName = cacheName;
+      this.storeType = type;
     }
 
     <T> TimelineFragment<T> setup(RequestWorkerBase<SortedCache<T>> worker,
                                   UserInfoPagerFragment target) {
-      worker.open(cacheName);
+      worker.open(storeType.storeName);
       worker.getCache().clear();
       final TimelineFragment<T> fragment = TimelineFragment.getInstance(target, requestCode);
       fragment.setSortedCache(worker.getCache());

--- a/app/src/main/java/com/freshdigitable/udonroad/datastore/BaseCache.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/datastore/BaseCache.java
@@ -22,9 +22,23 @@ package com.freshdigitable.udonroad.datastore;
  * Created by akihit on 2016/09/14.
  */
 public interface BaseCache {
+  /**
+   * opens data store resource. Depended data stores are also opened.
+   */
   void open();
 
+  /**
+   * deletes all stored entities. This operation should be called when the data store is opened.
+   */
   void clear();
 
+  /**
+   * closes data store resources. Depended data stores are also closed.
+   */
   void close();
+
+  /**
+   * removes the data store resource. This operation should be called when the data store is closed.
+   */
+  void drop();
 }

--- a/app/src/main/java/com/freshdigitable/udonroad/datastore/ConfigStore.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/datastore/ConfigStore.java
@@ -33,4 +33,6 @@ public interface ConfigStore extends TypedCache<StatusReaction> {
   void addIgnoringUser(User user);
 
   void removeIgnoringUser(User user);
+
+  void shrink();
 }

--- a/app/src/main/java/com/freshdigitable/udonroad/datastore/SortedCache.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/datastore/SortedCache.java
@@ -35,4 +35,6 @@ public interface SortedCache<T> extends BaseOperation<T> {
   long getLastPageCursor();
 
   void clearPool();
+
+  void drop(String storeName);
 }

--- a/app/src/main/java/com/freshdigitable/udonroad/datastore/StoreName.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/datastore/StoreName.java
@@ -21,8 +21,18 @@ package com.freshdigitable.udonroad.datastore;
  */
 
 public enum StoreName {
-  HOME,
-  USER_HOME, USER_FAV, USER_FRIEND, USER_FOLLOWER,
-  CONFIG,
-  APP_SETTINGS
+  HOME("home"),
+  USER_HOME("user_home"),
+  USER_FAV("user_favs"),
+  USER_FRIEND("user_friends"),
+  USER_FOLLOWER("user_followers"),
+  CONVERSATION("conv"),
+  CONFIG("config"),
+  APP_SETTINGS("appSettings");
+
+  private final String cacheName;
+
+  StoreName(String cacheName) {
+    this.cacheName = cacheName;
+  }
 }

--- a/app/src/main/java/com/freshdigitable/udonroad/datastore/StoreName.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/datastore/StoreName.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2017. Matsuda, Akihit (akihito104)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.freshdigitable.udonroad.datastore;
+
+/**
+ * Created by akihit on 2017/03/21.
+ */
+
+public enum StoreName {
+  HOME,
+  USER_HOME, USER_FAV, USER_FRIEND, USER_FOLLOWER,
+  CONFIG,
+  APP_SETTINGS
+}

--- a/app/src/main/java/com/freshdigitable/udonroad/datastore/UpdateEvent.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/datastore/UpdateEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016. Matsuda, Akihit (akihito104)
+ * Copyright (c) 2017. Matsuda, Akihit (akihito104)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,23 +16,20 @@
 
 package com.freshdigitable.udonroad.datastore;
 
-import rx.Observable;
-
 /**
- * SortedCache defines to access storage of sorted data specified type parameter.
- *
- * Created by akihit on 2016/09/14.
+ * Created by akihit on 2017/03/28.
  */
-public interface SortedCache<T> extends BaseOperation<T> {
-  void open(String storeName);
 
-  Observable<UpdateEvent> observeUpdateEvent();
+public class UpdateEvent {
+  public final EventType type;
+  public final int index;
 
-  T get(int position);
+  public UpdateEvent(EventType type, int index) {
+    this.type = type;
+    this.index = index;
+  }
 
-  int getItemCount();
-
-  long getLastPageCursor();
-
-  void clearPool();
+  public enum EventType {
+    INSERT, CHANGE, DELETE
+  }
 }

--- a/app/src/main/java/com/freshdigitable/udonroad/datastore/UpdateSubject.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/datastore/UpdateSubject.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2017. Matsuda, Akihit (akihito104)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.freshdigitable.udonroad.datastore;
+
+import rx.Observable;
+import rx.subjects.PublishSubject;
+
+/**
+ * Created by akihit on 2017/03/28.
+ */
+
+public class UpdateSubject {
+  private final PublishSubject<UpdateEvent> eventPublishSubject;
+  private final String name;
+
+  UpdateSubject(String name) {
+    this.name = name;
+    eventPublishSubject = PublishSubject.create();
+  }
+
+  public Observable<UpdateEvent> observeUpdateEvent() {
+    return eventPublishSubject.onBackpressureBuffer();
+  }
+
+  public void onComplete() {
+    if (!eventPublishSubject.hasCompleted()) {
+      eventPublishSubject.onCompleted();
+    }
+  }
+
+  public boolean hasCompleted() {
+    return eventPublishSubject.hasCompleted();
+  }
+
+  public boolean hasObservers() {
+    return eventPublishSubject.hasObservers();
+  }
+
+  public void onNext(UpdateEvent.EventType type, int index) {
+    onNext(new UpdateEvent(type, index));
+  }
+
+  public void onNext(UpdateEvent updateEvent) {
+    eventPublishSubject.onNext(updateEvent);
+  }
+}

--- a/app/src/main/java/com/freshdigitable/udonroad/datastore/UpdateSubjectFactory.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/datastore/UpdateSubjectFactory.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2017. Matsuda, Akihit (akihito104)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.freshdigitable.udonroad.datastore;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Created by akihit on 2017/03/28.
+ */
+
+public class UpdateSubjectFactory {
+  private final Map<String, UpdateSubject> subjectTable = new HashMap<>();
+
+  public UpdateSubject getInstance(String name) {
+    if (subjectTable.containsKey(name)) {
+      final UpdateSubject updateSubject = subjectTable.get(name);
+      if (!updateSubject.hasCompleted()) {
+        return updateSubject;
+      }
+      subjectTable.remove(name);
+    }
+    final UpdateSubject updateSubject = new UpdateSubject(name);
+    subjectTable.put(name, updateSubject);
+    return updateSubject;
+  }
+
+  public void clear() {
+    for (String name : subjectTable.keySet()) {
+      subjectTable.get(name).onComplete();
+    }
+    subjectTable.clear();
+  }
+}

--- a/app/src/main/java/com/freshdigitable/udonroad/module/AppComponent.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/module/AppComponent.java
@@ -22,6 +22,7 @@ import com.freshdigitable.udonroad.MediaViewActivity.MediaFragment;
 import com.freshdigitable.udonroad.OAuthActivity;
 import com.freshdigitable.udonroad.ReplyActivity;
 import com.freshdigitable.udonroad.StatusDetailFragment;
+import com.freshdigitable.udonroad.TimelineFragment;
 import com.freshdigitable.udonroad.TweetInputFragment;
 import com.freshdigitable.udonroad.UserInfoActivity;
 import com.freshdigitable.udonroad.UserInfoFragment;
@@ -61,4 +62,8 @@ public interface AppComponent {
   void inject(UserInfoPagerFragment userInfoPagerFragment);
 
   void inject(MediaFragment mediaFragment);
+
+  void inject(TimelineFragment.StatusListFragment timelineFragment);
+
+  void inject(TimelineFragment.UserListFragment timelineFragment);
 }

--- a/app/src/main/java/com/freshdigitable/udonroad/module/DataStoreModule.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/module/DataStoreModule.java
@@ -31,6 +31,11 @@ import com.freshdigitable.udonroad.module.realm.StatusCacheRealm;
 import com.freshdigitable.udonroad.module.realm.TimelineStoreRealm;
 import com.freshdigitable.udonroad.module.realm.UserCacheRealm;
 import com.freshdigitable.udonroad.module.realm.UserSortedCacheRealm;
+import com.freshdigitable.udonroad.subscriber.ListRequestWorker;
+import com.freshdigitable.udonroad.subscriber.StatusListRequestWorker;
+import com.freshdigitable.udonroad.subscriber.StatusRequestWorker;
+import com.freshdigitable.udonroad.subscriber.UserListRequestWorker;
+import com.freshdigitable.udonroad.subscriber.UserRequestWorker;
 
 import javax.inject.Singleton;
 
@@ -54,43 +59,43 @@ public class DataStoreModule {
 
   @Singleton
   @Provides
-  public TypedCache<Status> provideTypedCacheStatus(ConfigStore configStore) {
+  TypedCache<Status> provideTypedCacheStatus(ConfigStore configStore) {
     return new StatusCacheRealm(configStore);
   }
 
   @Singleton
   @Provides
-  public MediaCache provideMediaCache(TypedCache<Status> configStore) {
+  MediaCache provideMediaCache(TypedCache<Status> configStore) {
     return ((StatusCacheRealm) configStore);
   }
 
   @Singleton
   @Provides
-  public TypedCache<User> provideTypedCacheUser() {
+  TypedCache<User> provideTypedCacheUser() {
     return new UserCacheRealm();
   }
 
   @Provides
   @Singleton
-  public UpdateSubjectFactory provideUpdateSubjectFactory() {
+  UpdateSubjectFactory provideUpdateSubjectFactory() {
     return new UpdateSubjectFactory();
   }
 
   @Provides
-  public SortedCache<Status> provideSortedCacheStatus(
+  SortedCache<Status> provideSortedCacheStatus(
       UpdateSubjectFactory factory, TypedCache<Status> statusCacheRealm, ConfigStore configStore) {
     return new TimelineStoreRealm(factory, statusCacheRealm, configStore);
   }
 
   @Provides
-  public SortedCache<User> provideSortedCacheUser(
+  SortedCache<User> provideSortedCacheUser(
       UpdateSubjectFactory factory, TypedCache<User> userCacheRealm) {
     return new UserSortedCacheRealm(factory, userCacheRealm);
   }
 
   @Singleton
   @Provides
-  public ConfigStore provideConfigStore() {
+  ConfigStore provideConfigStore() {
     return new ConfigStoreRealm();
   }
 
@@ -102,8 +107,20 @@ public class DataStoreModule {
 
   @Singleton
   @Provides
-  public AppSettingStore provideAppSettingStore(TypedCache<User> userTypedCache,
+  AppSettingStore provideAppSettingStore(TypedCache<User> userTypedCache,
                                                 SharedPreferences sharedPreferences) {
     return new AppSettingStoreRealm(userTypedCache, sharedPreferences);
+  }
+
+  @Provides
+  ListRequestWorker<Status> provideListRequestWorkerStatus(
+      StatusRequestWorker<SortedCache<Status>> worker) {
+    return new StatusListRequestWorker(worker);
+  }
+
+  @Provides
+  ListRequestWorker<User> provideListRequestWorkerUser(
+      UserRequestWorker<SortedCache<User>> worker) {
+    return new UserListRequestWorker(worker);
   }
 }

--- a/app/src/main/java/com/freshdigitable/udonroad/module/DataStoreModule.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/module/DataStoreModule.java
@@ -24,6 +24,7 @@ import com.freshdigitable.udonroad.datastore.ConfigStore;
 import com.freshdigitable.udonroad.datastore.MediaCache;
 import com.freshdigitable.udonroad.datastore.SortedCache;
 import com.freshdigitable.udonroad.datastore.TypedCache;
+import com.freshdigitable.udonroad.datastore.UpdateSubjectFactory;
 import com.freshdigitable.udonroad.module.realm.AppSettingStoreRealm;
 import com.freshdigitable.udonroad.module.realm.ConfigStoreRealm;
 import com.freshdigitable.udonroad.module.realm.StatusCacheRealm;
@@ -70,14 +71,21 @@ public class DataStoreModule {
   }
 
   @Provides
-  public SortedCache<Status> provideSortedCacheStatus(TypedCache<Status> statusCacheRealm,
-                                                      ConfigStore configStore) {
-    return new TimelineStoreRealm(statusCacheRealm, configStore);
+  @Singleton
+  public UpdateSubjectFactory provideUpdateSubjectFactory() {
+    return new UpdateSubjectFactory();
   }
 
   @Provides
-  public SortedCache<User> provideSortedCacheUser(TypedCache<User> userCacheRealm) {
-    return new UserSortedCacheRealm(userCacheRealm);
+  public SortedCache<Status> provideSortedCacheStatus(
+      UpdateSubjectFactory factory, TypedCache<Status> statusCacheRealm, ConfigStore configStore) {
+    return new TimelineStoreRealm(factory, statusCacheRealm, configStore);
+  }
+
+  @Provides
+  public SortedCache<User> provideSortedCacheUser(
+      UpdateSubjectFactory factory, TypedCache<User> userCacheRealm) {
+    return new UserSortedCacheRealm(factory, userCacheRealm);
   }
 
   @Singleton

--- a/app/src/main/java/com/freshdigitable/udonroad/module/realm/AppSettingStoreRealm.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/module/realm/AppSettingStoreRealm.java
@@ -112,6 +112,9 @@ public class AppSettingStoreRealm implements AppSettingStore {
   @Override
   public void setTwitterAPIConfig(final TwitterAPIConfiguration twitterAPIConfig) {
     realm.executeTransaction(_realm -> {
+      _realm.where(TwitterAPIConfigurationRealm.class)
+          .findAll()
+          .deleteAllFromRealm();
       final TwitterAPIConfigurationRealm twitterAPIConfiguration
           = new TwitterAPIConfigurationRealm(twitterAPIConfig);
       _realm.insertOrUpdate(twitterAPIConfiguration);

--- a/app/src/main/java/com/freshdigitable/udonroad/module/realm/AppSettingStoreRealm.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/module/realm/AppSettingStoreRealm.java
@@ -112,9 +112,7 @@ public class AppSettingStoreRealm implements AppSettingStore {
   @Override
   public void setTwitterAPIConfig(final TwitterAPIConfiguration twitterAPIConfig) {
     realm.executeTransaction(_realm -> {
-      _realm.where(TwitterAPIConfigurationRealm.class)
-          .findAll()
-          .deleteAllFromRealm();
+      _realm.delete(TwitterAPIConfigurationRealm.class);
       final TwitterAPIConfigurationRealm twitterAPIConfiguration
           = new TwitterAPIConfigurationRealm(twitterAPIConfig);
       _realm.insertOrUpdate(twitterAPIConfiguration);

--- a/app/src/main/java/com/freshdigitable/udonroad/module/realm/AppSettingStoreRealm.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/module/realm/AppSettingStoreRealm.java
@@ -18,6 +18,7 @@ package com.freshdigitable.udonroad.module.realm;
 
 import android.content.SharedPreferences;
 
+import com.freshdigitable.udonroad.StoreType;
 import com.freshdigitable.udonroad.datastore.AppSettingStore;
 import com.freshdigitable.udonroad.datastore.TypedCache;
 
@@ -47,7 +48,7 @@ public class AppSettingStoreRealm implements AppSettingStore {
   public AppSettingStoreRealm(TypedCache<User> userCacheRealm, SharedPreferences prefs) {
     this.cache = userCacheRealm;
     config = new RealmConfiguration.Builder()
-        .name("appSettings")
+        .name(StoreType.APP_SETTINGS.storeName)
         .deleteRealmIfMigrationNeeded()
         .build();
     this.prefs = prefs;

--- a/app/src/main/java/com/freshdigitable/udonroad/module/realm/AppSettingStoreRealm.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/module/realm/AppSettingStoreRealm.java
@@ -82,6 +82,11 @@ public class AppSettingStoreRealm implements AppSettingStore {
   }
 
   @Override
+  public void drop() {
+    Realm.deleteRealm(config);
+  }
+
+  @Override
   public void addAuthenticatedUser(final User authenticatedUser) {
     realm.executeTransaction(_realm -> {
       final UserRealm userRealm = new UserRealm(authenticatedUser);

--- a/app/src/main/java/com/freshdigitable/udonroad/module/realm/BaseCacheRealm.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/module/realm/BaseCacheRealm.java
@@ -82,6 +82,13 @@ abstract class BaseCacheRealm implements BaseCache {
     cache.close();
   }
 
+  @Override
+  public void drop() {
+    if (config != null) {
+      Realm.deleteRealm(config);
+    }
+  }
+
   static <T extends RealmModel> T findById(Realm realm, long id, Class<T> clz) {
     return realm.where(clz)
         .equalTo("id", id)

--- a/app/src/main/java/com/freshdigitable/udonroad/module/realm/BaseSortedCacheRealm.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/module/realm/BaseSortedCacheRealm.java
@@ -48,12 +48,16 @@ abstract class BaseSortedCacheRealm<T> implements SortedCache<T> {
   @CallSuper
   public void open(String storeName) {
     updateSubject = factory.getInstance(storeName);
-    final RealmConfiguration config = new RealmConfiguration.Builder()
-        .name(storeName)
-        .deleteRealmIfMigrationNeeded()
-        .build();
+    final RealmConfiguration config = getRealmConfiguration(storeName);
     realm = Realm.getInstance(config);
     Log.d(TAG, "openRealm: " + config.getRealmFileName());
+  }
+
+  private RealmConfiguration getRealmConfiguration(String storeName) {
+    return new RealmConfiguration.Builder()
+          .name(storeName)
+          .deleteRealmIfMigrationNeeded()
+          .build();
   }
 
   @Override
@@ -71,10 +75,11 @@ abstract class BaseSortedCacheRealm<T> implements SortedCache<T> {
 
   @Override
   public void drop(String storeName) {
-    final RealmConfiguration conf = new RealmConfiguration.Builder()
-        .name(storeName)
-        .build();
-    Realm.deleteRealm(conf);
+    final RealmConfiguration conf = getRealmConfiguration(storeName);
+    if (Realm.getGlobalInstanceCount(conf) <= 0) {
+      Log.d(TAG, "drop: " + storeName);
+      Realm.deleteRealm(conf);
+    }
   }
 
   @Override

--- a/app/src/main/java/com/freshdigitable/udonroad/module/realm/BaseSortedCacheRealm.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/module/realm/BaseSortedCacheRealm.java
@@ -63,8 +63,10 @@ abstract class BaseSortedCacheRealm<T> implements SortedCache<T> {
       return;
     }
     Log.d(TAG, "closeRealm: " + realm.getConfiguration().getRealmFileName());
-    updateSubject.onComplete();
     realm.close();
+    if (realm.isClosed()) {
+      updateSubject.onComplete();
+    }
   }
 
   @Override

--- a/app/src/main/java/com/freshdigitable/udonroad/module/realm/BaseSortedCacheRealm.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/module/realm/BaseSortedCacheRealm.java
@@ -68,12 +68,25 @@ abstract class BaseSortedCacheRealm<T> implements SortedCache<T> {
   }
 
   @Override
+  public void drop(String storeName) {
+    final RealmConfiguration conf = new RealmConfiguration.Builder()
+        .name(storeName)
+        .build();
+    Realm.deleteRealm(conf);
+  }
+
+  @Override
   public Observable<UpdateEvent> observeUpdateEvent() {
     return updateSubject.observeUpdateEvent();
   }
 
   @Override
   public void open() {
+    throw new RuntimeException();
+  }
+
+  @Override
+  public void drop() {
     throw new RuntimeException();
   }
 }

--- a/app/src/main/java/com/freshdigitable/udonroad/module/realm/ConfigStoreRealm.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/module/realm/ConfigStoreRealm.java
@@ -19,6 +19,7 @@ package com.freshdigitable.udonroad.module.realm;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
+import com.freshdigitable.udonroad.StoreType;
 import com.freshdigitable.udonroad.datastore.ConfigStore;
 import com.freshdigitable.udonroad.datastore.StatusReaction;
 
@@ -51,7 +52,7 @@ public class ConfigStoreRealm implements ConfigStore {
 
   public ConfigStoreRealm() {
     config = new RealmConfiguration.Builder()
-        .name("config")
+        .name(StoreType.CONFIG.storeName)
         .deleteRealmIfMigrationNeeded()
         .build();
   }

--- a/app/src/main/java/com/freshdigitable/udonroad/module/realm/ConfigStoreRealm.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/module/realm/ConfigStoreRealm.java
@@ -201,4 +201,15 @@ public class ConfigStoreRealm implements ConfigStore {
         .findAll()
         .deleteAllFromRealm());
   }
+
+  @Override
+  public void shrink() {
+    configStore.executeTransaction(r -> r.where(StatusReactionRealm.class)
+        .beginGroup()
+        .equalTo("retweeted", false)
+        .equalTo("favorited", false)
+        .endGroup()
+        .findAll()
+        .deleteAllFromRealm());
+  }
 }

--- a/app/src/main/java/com/freshdigitable/udonroad/module/realm/ConfigStoreRealm.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/module/realm/ConfigStoreRealm.java
@@ -73,6 +73,11 @@ public class ConfigStoreRealm implements ConfigStore {
   }
 
   @Override
+  public void drop() {
+    Realm.deleteRealm(config);
+  }
+
+  @Override
   public void replaceIgnoringUsers(final Collection<Long> iDs) {
     configStore.executeTransaction(realm -> {
       realm.delete(IgnoringUser.class);

--- a/app/src/main/java/com/freshdigitable/udonroad/module/realm/TimelineStoreRealm.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/module/realm/TimelineStoreRealm.java
@@ -69,7 +69,10 @@ public class TimelineStoreRealm extends BaseSortedCacheRealm<Status> {
     timeline = realm
         .where(StatusIDs.class)
         .findAllSorted(KEY_ID, Sort.DESCENDING);
-    setItemCount(0);
+    setItemCount(timeline.size());
+    timeline.addChangeListener(elem -> {
+      setItemCount(elem.size());
+    });
   }
 
   @Override

--- a/app/src/main/java/com/freshdigitable/udonroad/module/realm/UserSortedCacheRealm.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/module/realm/UserSortedCacheRealm.java
@@ -20,6 +20,8 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 import com.freshdigitable.udonroad.datastore.TypedCache;
+import com.freshdigitable.udonroad.datastore.UpdateEvent.EventType;
+import com.freshdigitable.udonroad.datastore.UpdateSubjectFactory;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -40,7 +42,8 @@ public class UserSortedCacheRealm extends BaseSortedCacheRealm<User> {
   private TypedCache<User> userCache;
   private RealmResults<ListedUserIDs> ordered;
 
-  public UserSortedCacheRealm(TypedCache<User> userCacheRealm) {
+  public UserSortedCacheRealm(UpdateSubjectFactory factory, TypedCache<User> userCacheRealm) {
+    super(factory);
     this.userCache = userCacheRealm;
   }
 
@@ -109,7 +112,7 @@ public class UserSortedCacheRealm extends BaseSortedCacheRealm<User> {
     realm.beginTransaction();
     final List<ListedUserIDs> inserted = realm.copyToRealmOrUpdate(inserts);
     realm.commitTransaction();
-    if (inserted.isEmpty() || !insertEvent.hasObservers()) {
+    if (inserted.isEmpty() || !updateSubject.hasObservers()) {
       return;
     }
     updateCursorList(entities);
@@ -117,7 +120,7 @@ public class UserSortedCacheRealm extends BaseSortedCacheRealm<User> {
       @Override
       public void onChange(RealmResults<ListedUserIDs> element) {
         for (ListedUserIDs ids: inserted) {
-          insertEvent.onNext(ids.order);
+          updateSubject.onNext(EventType.INSERT, ids.order);
         }
         element.removeChangeListener(this);
       }

--- a/app/src/main/java/com/freshdigitable/udonroad/subscriber/ConfigRequestWorker.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/subscriber/ConfigRequestWorker.java
@@ -189,4 +189,8 @@ public class ConfigRequestWorker extends RequestWorkerBase<ConfigStore> {
   private Action1<User> removeIgnoringUserAction() {
     return user -> cache.removeIgnoringUser(user);
   }
+
+  public void shrink() {
+    cache.shrink();
+  }
 }

--- a/app/src/main/java/com/freshdigitable/udonroad/subscriber/ListFetchStrategy.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/subscriber/ListFetchStrategy.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2017. Matsuda, Akihit (akihito104)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.freshdigitable.udonroad.subscriber;
+
+import twitter4j.Paging;
+
+/**
+ * Created by akihit on 2017/03/30.
+ */
+
+public interface ListFetchStrategy {
+  void fetch();
+
+  void fetch(Paging paging);
+}

--- a/app/src/main/java/com/freshdigitable/udonroad/subscriber/ListRequestWorker.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/subscriber/ListRequestWorker.java
@@ -29,6 +29,8 @@ public interface ListRequestWorker<T> {
 
   void close();
 
+  void drop();
+
   SortedCache<T> getCache();
 
   ListFetchStrategy getFetchStrategy(long id);

--- a/app/src/main/java/com/freshdigitable/udonroad/subscriber/ListRequestWorker.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/subscriber/ListRequestWorker.java
@@ -18,6 +18,7 @@ package com.freshdigitable.udonroad.subscriber;
 
 import com.freshdigitable.udonroad.StoreType;
 import com.freshdigitable.udonroad.datastore.SortedCache;
+import com.freshdigitable.udonroad.ffab.IndicatableFFAB.OnIffabItemSelectedListener;
 
 /**
  * Created by akihit on 2017/03/31.
@@ -31,4 +32,6 @@ public interface ListRequestWorker<T> {
   SortedCache<T> getCache();
 
   ListFetchStrategy getFetchStrategy(long id);
+
+  OnIffabItemSelectedListener getOnIffabItemSelectedListener(long selectedId);
 }

--- a/app/src/main/java/com/freshdigitable/udonroad/subscriber/ListRequestWorker.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/subscriber/ListRequestWorker.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2017. Matsuda, Akihit (akihito104)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.freshdigitable.udonroad.subscriber;
+
+import com.freshdigitable.udonroad.StoreType;
+import com.freshdigitable.udonroad.datastore.SortedCache;
+
+/**
+ * Created by akihit on 2017/03/31.
+ */
+
+public interface ListRequestWorker<T> {
+  void open(StoreType type, String suffix);
+
+  SortedCache<T> getCache();
+
+  ListFetchStrategy getFetchStrategy(long id);
+}

--- a/app/src/main/java/com/freshdigitable/udonroad/subscriber/ListRequestWorker.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/subscriber/ListRequestWorker.java
@@ -26,6 +26,8 @@ import com.freshdigitable.udonroad.datastore.SortedCache;
 public interface ListRequestWorker<T> {
   void open(StoreType type, String suffix);
 
+  void close();
+
   SortedCache<T> getCache();
 
   ListFetchStrategy getFetchStrategy(long id);

--- a/app/src/main/java/com/freshdigitable/udonroad/subscriber/StatusListRequestWorker.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/subscriber/StatusListRequestWorker.java
@@ -31,12 +31,12 @@ import twitter4j.Status;
  * Created by akihit on 2017/03/31.
  */
 
-class StatusListRequestWorker implements ListRequestWorker<Status> {
+public class StatusListRequestWorker implements ListRequestWorker<Status> {
   private final StatusRequestWorker<SortedCache<Status>> requestWorker;
   private StoreType storeType;
 
   @Inject
-  StatusListRequestWorker(StatusRequestWorker<SortedCache<Status>> requestWorker) {
+  public StatusListRequestWorker(StatusRequestWorker<SortedCache<Status>> requestWorker) {
     this.requestWorker = requestWorker;
   }
 
@@ -107,5 +107,10 @@ class StatusListRequestWorker implements ListRequestWorker<Status> {
       };
     }
     throw new IllegalStateException();
+  }
+
+  @Override
+  public void close() {
+    requestWorker.close();
   }
 }

--- a/app/src/main/java/com/freshdigitable/udonroad/subscriber/StatusListRequestWorker.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/subscriber/StatusListRequestWorker.java
@@ -40,6 +40,7 @@ import twitter4j.Status;
 public class StatusListRequestWorker implements ListRequestWorker<Status> {
   private final StatusRequestWorker<SortedCache<Status>> requestWorker;
   private StoreType storeType;
+  private String storeName;
 
   @Inject
   public StatusListRequestWorker(StatusRequestWorker<SortedCache<Status>> requestWorker) {
@@ -52,9 +53,9 @@ public class StatusListRequestWorker implements ListRequestWorker<Status> {
       throw new IllegalArgumentException();
     }
     this.storeType = type;
-    final String name = TextUtils.isEmpty(suffix)
+    storeName = TextUtils.isEmpty(suffix)
         ? type.storeName : type.prefix() + suffix;
-    requestWorker.open(name);
+    requestWorker.open(storeName);
   }
 
   @Override
@@ -143,5 +144,10 @@ public class StatusListRequestWorker implements ListRequestWorker<Status> {
   @Override
   public void close() {
     requestWorker.close();
+  }
+
+  @Override
+  public void drop() {
+    requestWorker.getCache().drop(storeName);
   }
 }

--- a/app/src/main/java/com/freshdigitable/udonroad/subscriber/StatusListRequestWorker.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/subscriber/StatusListRequestWorker.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2017. Matsuda, Akihit (akihito104)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.freshdigitable.udonroad.subscriber;
+
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import com.freshdigitable.udonroad.StoreType;
+import com.freshdigitable.udonroad.datastore.SortedCache;
+
+import javax.inject.Inject;
+
+import twitter4j.Paging;
+import twitter4j.Status;
+
+/**
+ * Created by akihit on 2017/03/31.
+ */
+
+class StatusListRequestWorker implements ListRequestWorker<Status> {
+  private final StatusRequestWorker<SortedCache<Status>> requestWorker;
+  private StoreType storeType;
+
+  @Inject
+  StatusListRequestWorker(StatusRequestWorker<SortedCache<Status>> requestWorker) {
+    this.requestWorker = requestWorker;
+  }
+
+  @Override
+  public void open(@NonNull StoreType type, @Nullable String suffix) {
+    if (!type.isForStatus()) {
+      throw new IllegalArgumentException();
+    }
+    this.storeType = type;
+    final String name = suffix == null || suffix.length() <= 0
+        ? type.storeName : type.prefix() + suffix;
+    requestWorker.open(name);
+  }
+
+  @Override
+  public SortedCache<Status> getCache() {
+    return requestWorker.getCache();
+  }
+
+  @Override
+  public ListFetchStrategy getFetchStrategy(final long id) {
+    if (storeType == StoreType.HOME) {
+      return new ListFetchStrategy() {
+        @Override
+        public void fetch() {
+          requestWorker.fetchHomeTimeline();
+        }
+
+        @Override
+        public void fetch(Paging paging) {
+          requestWorker.fetchHomeTimeline(paging);
+        }
+      };
+    } else if (storeType == StoreType.USER_HOME) {
+      return new ListFetchStrategy() {
+        @Override
+        public void fetch() {
+          requestWorker.fetchHomeTimeline(id);
+        }
+
+        @Override
+        public void fetch(Paging paging) {
+          requestWorker.fetchHomeTimeline(id, paging);
+        }
+      };
+    } else if (storeType == StoreType.USER_FAV) {
+      return new ListFetchStrategy() {
+        @Override
+        public void fetch() {
+          requestWorker.fetchFavorites(id);
+        }
+
+        @Override
+        public void fetch(Paging paging) {
+          requestWorker.fetchFavorites(id, paging);
+        }
+      };
+    } else if (storeType == StoreType.CONVERSATION) {
+      return new ListFetchStrategy() {
+        @Override
+        public void fetch() {
+          requestWorker.fetchConversations(id);
+        }
+
+        @Override
+        public void fetch(Paging paging) {
+        }
+      };
+    }
+    throw new IllegalStateException();
+  }
+}

--- a/app/src/main/java/com/freshdigitable/udonroad/subscriber/UserListRequestWorker.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/subscriber/UserListRequestWorker.java
@@ -20,6 +20,7 @@ import android.text.TextUtils;
 
 import com.freshdigitable.udonroad.StoreType;
 import com.freshdigitable.udonroad.datastore.SortedCache;
+import com.freshdigitable.udonroad.ffab.IndicatableFFAB.OnIffabItemSelectedListener;
 
 import javax.inject.Inject;
 
@@ -83,6 +84,11 @@ public class UserListRequestWorker implements ListRequestWorker<User> {
       };
     }
     throw new IllegalStateException();
+  }
+
+  @Override
+  public OnIffabItemSelectedListener getOnIffabItemSelectedListener(long selectedId) {
+    return item -> { /* nop */ };
   }
 
   @Override

--- a/app/src/main/java/com/freshdigitable/udonroad/subscriber/UserListRequestWorker.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/subscriber/UserListRequestWorker.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2017. Matsuda, Akihit (akihito104)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.freshdigitable.udonroad.subscriber;
+
+import android.text.TextUtils;
+
+import com.freshdigitable.udonroad.StoreType;
+import com.freshdigitable.udonroad.datastore.SortedCache;
+
+import javax.inject.Inject;
+
+import twitter4j.Paging;
+import twitter4j.User;
+
+/**
+ * Created by akihit on 2017/03/31.
+ */
+
+class UserListRequestWorker implements ListRequestWorker<User> {
+  private final UserRequestWorker<SortedCache<User>> requestWorker;
+  private StoreType storeType;
+
+  @Inject
+  UserListRequestWorker(UserRequestWorker<SortedCache<User>> requestWorker) {
+    this.requestWorker = requestWorker;
+  }
+
+  @Override
+  public void open(StoreType type, String suffix) {
+    if (!type.isForUser()) {
+      throw new IllegalArgumentException();
+    }
+    this.storeType = type;
+    String name = TextUtils.isEmpty(suffix)
+        ? type.storeName : type.prefix() + suffix;
+    requestWorker.open(name);
+  }
+
+  @Override
+  public SortedCache<User> getCache() {
+    return requestWorker.getCache();
+  }
+
+  @Override
+  public ListFetchStrategy getFetchStrategy(final long userId) {
+    if (storeType == StoreType.USER_FOLLOWER) {
+      return new ListFetchStrategy() {
+        @Override
+        public void fetch() {
+          requestWorker.fetchFollowers(userId, -1);
+        }
+
+        @Override
+        public void fetch(Paging paging) {
+          requestWorker.fetchFollowers(userId, paging.getMaxId());
+        }
+      };
+    } else if (storeType == StoreType.USER_FRIEND) {
+      return new ListFetchStrategy() {
+        @Override
+        public void fetch() {
+          requestWorker.fetchFriends(userId, -1);
+        }
+
+        @Override
+        public void fetch(Paging paging) {
+          requestWorker.fetchFriends(userId, paging.getMaxId());
+        }
+      };
+    }
+    throw new IllegalStateException();
+  }
+}

--- a/app/src/main/java/com/freshdigitable/udonroad/subscriber/UserListRequestWorker.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/subscriber/UserListRequestWorker.java
@@ -34,6 +34,7 @@ import twitter4j.User;
 public class UserListRequestWorker implements ListRequestWorker<User> {
   private final UserRequestWorker<SortedCache<User>> requestWorker;
   private StoreType storeType;
+  private String storeName;
 
   @Inject
   public UserListRequestWorker(UserRequestWorker<SortedCache<User>> requestWorker) {
@@ -46,9 +47,9 @@ public class UserListRequestWorker implements ListRequestWorker<User> {
       throw new IllegalArgumentException();
     }
     this.storeType = type;
-    String name = TextUtils.isEmpty(suffix)
+    storeName = TextUtils.isEmpty(suffix)
         ? type.storeName : type.prefix() + suffix;
-    requestWorker.open(name);
+    requestWorker.open(storeName);
   }
 
   @Override
@@ -94,5 +95,10 @@ public class UserListRequestWorker implements ListRequestWorker<User> {
   @Override
   public void close() {
     requestWorker.close();
+  }
+
+  @Override
+  public void drop() {
+    requestWorker.getCache().drop(storeName);
   }
 }

--- a/app/src/main/java/com/freshdigitable/udonroad/subscriber/UserListRequestWorker.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/subscriber/UserListRequestWorker.java
@@ -30,12 +30,12 @@ import twitter4j.User;
  * Created by akihit on 2017/03/31.
  */
 
-class UserListRequestWorker implements ListRequestWorker<User> {
+public class UserListRequestWorker implements ListRequestWorker<User> {
   private final UserRequestWorker<SortedCache<User>> requestWorker;
   private StoreType storeType;
 
   @Inject
-  UserListRequestWorker(UserRequestWorker<SortedCache<User>> requestWorker) {
+  public UserListRequestWorker(UserRequestWorker<SortedCache<User>> requestWorker) {
     this.requestWorker = requestWorker;
   }
 
@@ -83,5 +83,10 @@ class UserListRequestWorker implements ListRequestWorker<User> {
       };
     }
     throw new IllegalStateException();
+  }
+
+  @Override
+  public void close() {
+    requestWorker.close();
   }
 }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -76,7 +76,9 @@
                 android:layout_height="wrap_content"
                 android:layout_marginBottom="@dimen/iffab_margin_bottom"
                 android:layout_gravity="center_horizontal|bottom"
+                android:visibility="invisible"
                 app:menu="@menu/iffab_main"
+                tools:visibility="visible"
                 />
 
         </android.support.design.widget.CoordinatorLayout>


### PR DESCRIPTION
データストア名とデータ更新イベントの通知ストリームとを対応させ、複数のインスタンスからデータストアを更新されても更新イベントの通知を受け取れるようにする。

- [x] データストアに関する設定を整理する
- [x] データストア名とデータ更新イベントストリームとの対応を管理できるようにする
- [x] APIフェッチを`TimelineFragment`で行うようにし、Activity等から極力排除する
- [x] 不要なデータをclean upできるようにする #199 