### PR TITLE
Implement timeline container switcher

### DIFF
--- a/app/src/androidTest/java/com/freshdigitable/udonroad/MockAppComponent.java
+++ b/app/src/androidTest/java/com/freshdigitable/udonroad/MockAppComponent.java
@@ -16,7 +16,6 @@
 
 package com.freshdigitable.udonroad;
 
-import com.freshdigitable.udonroad.UserInfoActivityInstTest.UserInfoActivityInstTestBase;
 import com.freshdigitable.udonroad.module.AppComponent;
 import com.freshdigitable.udonroad.module.DataStoreModule;
 import com.freshdigitable.udonroad.module.TwitterApiModule;
@@ -36,7 +35,7 @@ import dagger.Component;
 public interface MockAppComponent extends AppComponent {
   void inject(TimelineInstTestBase mainActivityInstTest);
 
-  void inject(UserInfoActivityInstTestBase userInfoActivityInstTest);
+  void inject(UserInfoActivityInstTest.Base userInfoActivityInstTest);
 
   void inject(OAuthActivityInstTest oAuthActivityInstTest);
 }

--- a/app/src/androidTest/java/com/freshdigitable/udonroad/UserInfoActivityInstTest.java
+++ b/app/src/androidTest/java/com/freshdigitable/udonroad/UserInfoActivityInstTest.java
@@ -75,7 +75,7 @@ import static org.mockito.Mockito.when;
  */
 @RunWith(Enclosed.class)
 public class UserInfoActivityInstTest {
-  public static class WhenTargetIsFollowed extends UserInfoActivityInstTestBase {
+  public static class WhenTargetIsFollowed extends Base {
     @Override
     protected int setupTimeline() throws TwitterException {
       final Relationship relationship = mock(Relationship.class);
@@ -140,7 +140,7 @@ public class UserInfoActivityInstTest {
     }
   }
 
-  public static class WhenTargetIsNotFollowed extends UserInfoActivityInstTestBase {
+  public static class WhenTargetIsNotFollowed extends Base {
     @Override
     protected int setupTimeline() throws TwitterException {
       final Relationship relationship = mock(Relationship.class);
@@ -208,7 +208,7 @@ public class UserInfoActivityInstTest {
     }
   }
 
-  public static class WhenTargetIsBlocked extends UserInfoActivityInstTestBase {
+  public static class WhenTargetIsBlocked extends Base {
     @Override
     protected int setupTimeline() throws TwitterException {
       final Relationship relationship = mock(Relationship.class);
@@ -247,7 +247,7 @@ public class UserInfoActivityInstTest {
     }
   }
 
-  public static class WhenTargetIsMuted extends UserInfoActivityInstTestBase {
+  public static class WhenTargetIsMuted extends Base {
     @Override
     protected int setupTimeline() throws TwitterException {
       final Relationship relationship = mock(Relationship.class);
@@ -286,7 +286,7 @@ public class UserInfoActivityInstTest {
     }
   }
 
-  public static class WhenTargetIsFollowedAndMuted extends UserInfoActivityInstTestBase {
+  public static class WhenTargetIsFollowedAndMuted extends Base {
     @Override
     protected int setupTimeline() throws TwitterException {
       final Relationship relationship = mock(Relationship.class);
@@ -311,7 +311,7 @@ public class UserInfoActivityInstTest {
     }
   }
 
-  public static class WhenTargetIsBlockedRetweet extends UserInfoActivityInstTestBase {
+  public static class WhenTargetIsBlockedRetweet extends Base {
     @Override
     protected int setupTimeline() throws TwitterException {
       final Relationship relationship = mock(Relationship.class);
@@ -384,7 +384,7 @@ public class UserInfoActivityInstTest {
     }
   }
 
-  public abstract static class UserInfoActivityInstTestBase extends TimelineInstTestBase {
+  public abstract static class Base extends TimelineInstTestBase {
     @Rule
     public final ActivityTestRule<UserInfoActivity> rule
         = new ActivityTestRule<>(UserInfoActivity.class, false, false);

--- a/app/src/androidTest/java/com/freshdigitable/udonroad/UserInfoActivityTimelineTest.java
+++ b/app/src/androidTest/java/com/freshdigitable/udonroad/UserInfoActivityTimelineTest.java
@@ -32,6 +32,7 @@ import static android.support.test.espresso.matcher.ViewMatchers.isCompletelyDis
 import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
 import static android.support.test.espresso.matcher.ViewMatchers.withText;
+import static org.hamcrest.CoreMatchers.not;
 import static org.mockito.Mockito.mock;
 
 /**
@@ -49,8 +50,10 @@ public class UserInfoActivityTimelineTest extends UserInfoActivityInstTest.Base 
     onView(withText("TWEET\n20")).check(matches(isDisplayed()));
     PerformUtil.selectItemViewAt(0);
     PerformUtil.showDetail();
+    onView(withId(R.id.userInfo_tabs)).check(matches(not(isDisplayed())));
     onView(withId(R.id.action_heading)).check(doesNotExist());
     Espresso.pressBack();
+    onView(withId(R.id.userInfo_tabs)).check(matches(isDisplayed()));
     onView(withId(R.id.ffab)).check(matches(isCompletelyDisplayed()));
   }
 }

--- a/app/src/androidTest/java/com/freshdigitable/udonroad/UserInfoActivityTimelineTest.java
+++ b/app/src/androidTest/java/com/freshdigitable/udonroad/UserInfoActivityTimelineTest.java
@@ -26,6 +26,7 @@ import twitter4j.Relationship;
 import twitter4j.TwitterException;
 
 import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.assertion.ViewAssertions.doesNotExist;
 import static android.support.test.espresso.assertion.ViewAssertions.matches;
 import static android.support.test.espresso.matcher.ViewMatchers.isCompletelyDisplayed;
 import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
@@ -48,7 +49,7 @@ public class UserInfoActivityTimelineTest extends UserInfoActivityInstTest.Base 
     onView(withText("TWEET\n20")).check(matches(isDisplayed()));
     PerformUtil.selectItemViewAt(0);
     PerformUtil.showDetail();
-    onView(withText("TWEET\n20")).check(matches(isDisplayed()));
+    onView(withId(R.id.action_heading)).check(doesNotExist());
     Espresso.pressBack();
     onView(withId(R.id.ffab)).check(matches(isCompletelyDisplayed()));
   }

--- a/app/src/androidTest/java/com/freshdigitable/udonroad/UserInfoActivityTimelineTest.java
+++ b/app/src/androidTest/java/com/freshdigitable/udonroad/UserInfoActivityTimelineTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2017. Matsuda, Akihit (akihito104)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.freshdigitable.udonroad;
+
+import android.support.test.espresso.Espresso;
+
+import com.freshdigitable.udonroad.util.PerformUtil;
+
+import org.junit.Test;
+
+import twitter4j.Relationship;
+import twitter4j.TwitterException;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.ViewMatchers.isCompletelyDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Created by akihit on 2017/07/07.
+ */
+public class UserInfoActivityTimelineTest extends UserInfoActivityInstTest.Base {
+  @Override
+  protected int setupTimeline() throws TwitterException {
+    final Relationship relationship = mock(Relationship.class);
+    return setupUserInfoTimeline(relationship);
+  }
+
+  @Test
+  public void showStatusDetail() throws Exception {
+    onView(withText("TWEET\n20")).check(matches(isDisplayed()));
+    PerformUtil.selectItemViewAt(0);
+    PerformUtil.showDetail();
+    onView(withText("TWEET\n20")).check(matches(isDisplayed()));
+    Espresso.pressBack();
+    onView(withId(R.id.ffab)).check(matches(isCompletelyDisplayed()));
+  }
+}

--- a/app/src/main/java/com/freshdigitable/udonroad/ItemSelectable.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/ItemSelectable.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2017. Matsuda, Akihit (akihito104)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.freshdigitable.udonroad;
+
+/**
+ * Created by akihit on 2017/07/07.
+ */
+
+interface ItemSelectable {
+  boolean isItemSelected();
+
+  void clearSelectedItem();
+}

--- a/app/src/main/java/com/freshdigitable/udonroad/MainActivity.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/MainActivity.java
@@ -185,11 +185,19 @@ public class MainActivity extends AppCompatActivity
       supportActionBar.setHomeButtonEnabled(true);
     }
     setupActionMap();
+    timelineContainerSwitcher.setOnMainFragmentSwitchedListener(isAppeared -> {
+      if (isAppeared) {
+        tlFragment.startScroll();
+      } else {
+        tlFragment.stopScroll();
+      }
+    });
   }
 
   @Override
   protected void onStop() {
     super.onStop();
+    timelineContainerSwitcher.setOnMainFragmentSwitchedListener(null);
     binding.ffab.setOnIffabItemSelectedListener(null);
     if (subscription != null && !subscription.isDisposed()) {
       subscription.dispose();
@@ -294,7 +302,6 @@ public class MainActivity extends AppCompatActivity
       final long selectedTweetId = tlFragment.getSelectedTweetId();
       if (itemId == R.id.iffabMenu_main_detail) {
         timelineContainerSwitcher.showStatusDetail(selectedTweetId);
-        tlFragment.stopScroll();
       } else if (itemId == R.id.iffabMenu_main_reply) {
         sendStatusSelected(TYPE_REPLY, selectedTweetId);
         tlFragment.scrollToSelectedItem();

--- a/app/src/main/java/com/freshdigitable/udonroad/TimelineContainerSwitcher.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/TimelineContainerSwitcher.java
@@ -16,12 +16,15 @@
 
 package com.freshdigitable.udonroad;
 
+import android.content.Context;
 import android.support.annotation.IdRes;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentTransaction;
 import android.view.Menu;
 import android.view.View;
+import android.view.animation.Animation;
+import android.view.animation.AnimationUtils;
 
 import com.freshdigitable.udonroad.TimelineFragment.StatusListFragment;
 import com.freshdigitable.udonroad.ffab.IndicatableFFAB;
@@ -142,9 +145,28 @@ class TimelineContainerSwitcher {
     void onMainFragmentSwitched(boolean isAppeared);
   }
 
-  private OnMainFragmentSwitchedListener listener;
+  private static final OnMainFragmentSwitchedListener EMPTY_LISTENER = a -> {};
+  private OnMainFragmentSwitchedListener listener = EMPTY_LISTENER;
 
   void setOnMainFragmentSwitchedListener(OnMainFragmentSwitchedListener listener) {
-    this.listener = listener;
+    this.listener = listener != null ? listener : EMPTY_LISTENER;
+  }
+
+  static Animation makeSwitchingAnimation(Context context, int transit, boolean enter) {
+    if (transit == FragmentTransaction.TRANSIT_FRAGMENT_OPEN) {
+      if (!enter) {
+        return AnimationUtils.makeOutAnimation(context, true);
+      } else {
+        return AnimationUtils.makeInAnimation(context, false);
+      }
+    }
+    if (transit == FragmentTransaction.TRANSIT_FRAGMENT_CLOSE) {
+      if (enter) {
+        return AnimationUtils.makeInAnimation(context, false);
+      } else {
+        return AnimationUtils.makeOutAnimation(context, true);
+      }
+    }
+    return null;
   }
 }

--- a/app/src/main/java/com/freshdigitable/udonroad/TimelineContainerSwitcher.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/TimelineContainerSwitcher.java
@@ -52,7 +52,7 @@ class TimelineContainerSwitcher {
   }
 
   void showStatusDetail(long statusId) {
-    StatusDetailFragment statusDetail = StatusDetailFragment.getInstance(statusId);
+    final StatusDetailFragment statusDetail = StatusDetailFragment.getInstance(statusId);
     replaceTimelineContainer("detail_" + Long.toString(statusId), statusDetail);
     switchFFABMenuTo(R.id.iffabMenu_main_conv);
     ffab.transToToolbar();

--- a/app/src/main/java/com/freshdigitable/udonroad/TimelineContainerSwitcher.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/TimelineContainerSwitcher.java
@@ -75,6 +75,9 @@ class TimelineContainerSwitcher {
     } else {
       tag = "conv";
     }
+    if (current == mainFragment) {
+      listener.onMainFragmentSwitched(false);
+    }
     fm.beginTransaction()
         .replace(containerId, fragment, name)
         .addToBackStack(tag)
@@ -108,6 +111,7 @@ class TimelineContainerSwitcher {
     final FragmentManager.BackStackEntry backStack = fm.getBackStackEntryAt(backStackEntryCount - 1);
     final String appearFragmentName = backStack.getName();
     if ("main".equals(appearFragmentName)) {
+      listener.onMainFragmentSwitched(true);
       switchFFABMenuTo(R.id.iffabMenu_main_detail);
       ffab.transToFAB(((ItemSelectable) mainFragment).isItemSelected() ? View.VISIBLE : View.INVISIBLE);
     } else if ("detail".equals(appearFragmentName)) {
@@ -132,5 +136,15 @@ class TimelineContainerSwitcher {
 
   private FragmentManager getSupportFragmentManager() {
     return mainFragment.getActivity().getSupportFragmentManager();
+  }
+
+  interface OnMainFragmentSwitchedListener {
+    void onMainFragmentSwitched(boolean isAppeared);
+  }
+
+  private OnMainFragmentSwitchedListener listener;
+
+  void setOnMainFragmentSwitchedListener(OnMainFragmentSwitchedListener listener) {
+    this.listener = listener;
   }
 }

--- a/app/src/main/java/com/freshdigitable/udonroad/TimelineContainerSwitcher.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/TimelineContainerSwitcher.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2017. Matsuda, Akihit (akihito104)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.freshdigitable.udonroad;
+
+import android.support.annotation.IdRes;
+import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentManager;
+import android.support.v4.app.FragmentTransaction;
+import android.view.Menu;
+import android.view.View;
+
+import com.freshdigitable.udonroad.TimelineFragment.StatusListFragment;
+import com.freshdigitable.udonroad.ffab.IndicatableFFAB;
+
+import twitter4j.Status;
+
+import static com.freshdigitable.udonroad.StoreType.CONVERSATION;
+
+/**
+ * Created by akihit on 2017/07/07.
+ */
+
+class TimelineContainerSwitcher {
+  private final Fragment mainFragment;
+  private final IndicatableFFAB ffab;
+  private final @IdRes int containerId;
+
+  TimelineContainerSwitcher(View container, Fragment mainFragment, IndicatableFFAB iffab) {
+    if (!(mainFragment instanceof ItemSelectable)) {
+      throw new IllegalArgumentException("mainFragment should implement ItemSelectable.");
+    }
+    this.mainFragment = mainFragment;
+    this.ffab = iffab;
+    this.containerId = container.getId();
+  }
+
+  void showStatusDetail(long statusId) {
+    StatusDetailFragment statusDetail = StatusDetailFragment.getInstance(statusId);
+    replaceTimelineContainer("detail_" + Long.toString(statusId), statusDetail);
+    switchFFABMenuTo(R.id.iffabMenu_main_conv);
+    ffab.transToToolbar();
+  }
+
+  void showConversation(long statusId) {
+    ffab.transToFAB(View.INVISIBLE);
+    final TimelineFragment<Status> conversationFragment
+        = StatusListFragment.getInstance(CONVERSATION, statusId);
+    final String name = StoreType.CONVERSATION.prefix() + Long.toString(statusId);
+    replaceTimelineContainer(name, conversationFragment);
+    switchFFABMenuTo(R.id.iffabMenu_main_detail);
+  }
+
+  private void replaceTimelineContainer(String name, Fragment fragment) {
+    final FragmentManager fm = getSupportFragmentManager();
+    final Fragment current = fm.findFragmentById(containerId);
+    final String tag;
+    if (current == mainFragment) {
+      tag = "main";
+    } else if (current instanceof StatusDetailFragment) {
+      tag = "detail";
+    } else {
+      tag = "conv";
+    }
+    fm.beginTransaction()
+        .replace(containerId, fragment, name)
+        .addToBackStack(tag)
+        .setTransition(FragmentTransaction.TRANSIT_FRAGMENT_OPEN)
+        .commit();
+  }
+
+  boolean clearSelectedCursorIfNeeded() {
+    final Fragment fragment = getSupportFragmentManager().findFragmentById(containerId);
+    return fragment instanceof ItemSelectable
+        && clearSelectedCursorIfNeeded((ItemSelectable) fragment);
+  }
+
+  private boolean clearSelectedCursorIfNeeded(ItemSelectable fragment) {
+    if (fragment.isItemSelected()) {
+      fragment.clearSelectedItem();
+      return true;
+    }
+    return false;
+  }
+
+  boolean popBackStackTimelineContainer() {
+    final FragmentManager fm = getSupportFragmentManager();
+    final int backStackEntryCount = fm.getBackStackEntryCount();
+    if (backStackEntryCount <= 0) {
+      return false;
+    }
+
+    fm.popBackStack();
+
+    final FragmentManager.BackStackEntry backStack = fm.getBackStackEntryAt(backStackEntryCount - 1);
+    final String appearFragmentName = backStack.getName();
+    if ("main".equals(appearFragmentName)) {
+      switchFFABMenuTo(R.id.iffabMenu_main_detail);
+      ffab.transToFAB(((ItemSelectable) mainFragment).isItemSelected() ? View.VISIBLE : View.INVISIBLE);
+    } else if ("detail".equals(appearFragmentName)) {
+      switchFFABMenuTo(R.id.iffabMenu_main_conv);
+      ffab.transToToolbar();
+    } else if ("conv".equals(appearFragmentName)) {
+      switchFFABMenuTo(R.id.iffabMenu_main_detail);
+      ffab.transToFAB();
+    }
+    return true;
+  }
+
+  private static final int[] FFAB_MENU_LEFT_SETS
+      = {R.id.iffabMenu_main_conv, R.id.iffabMenu_main_detail};
+
+  private void switchFFABMenuTo(@IdRes int targetItem) {
+    final Menu menu = ffab.getMenu();
+    for (@IdRes int menuItemId : FFAB_MENU_LEFT_SETS) {
+      menu.findItem(menuItemId).setEnabled(menuItemId == targetItem);
+    }
+  }
+
+  private FragmentManager getSupportFragmentManager() {
+    return mainFragment.getActivity().getSupportFragmentManager();
+  }
+}

--- a/app/src/main/java/com/freshdigitable/udonroad/TimelineFragment.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/TimelineFragment.java
@@ -259,8 +259,6 @@ public abstract class TimelineFragment<T> extends Fragment implements ItemSelect
     if (isVisible()) {
       if (tlAdapter.isItemSelected()) {
         showFab();
-      } else {
-        hideFab();
       }
     }
   }

--- a/app/src/main/java/com/freshdigitable/udonroad/TimelineFragment.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/TimelineFragment.java
@@ -59,7 +59,7 @@ import twitter4j.User;
  *
  * Created by Akihit.
  */
-public abstract class TimelineFragment<T> extends Fragment {
+public abstract class TimelineFragment<T> extends Fragment implements ItemSelectable {
   @SuppressWarnings("unused")
   private static final String TAG = TimelineFragment.class.getSimpleName();
   public static final String BUNDLE_IS_SCROLLED_BY_USER = "is_scrolled_by_user";
@@ -401,7 +401,7 @@ public abstract class TimelineFragment<T> extends Fragment {
   }
 
   public void scrollToTop() {
-    clearSelectedTweet();
+    clearSelectedItem();
     binding.timeline.setLayoutFrozen(false);
     stopScroll = false;
     isScrolledByUser = false;
@@ -425,11 +425,13 @@ public abstract class TimelineFragment<T> extends Fragment {
     }
   }
 
-  public void clearSelectedTweet() {
+  @Override
+  public void clearSelectedItem() {
     tlAdapter.clearSelectedItem();
   }
 
-  public boolean isTweetSelected() {
+  @Override
+  public boolean isItemSelected() {
     return tlAdapter != null && tlAdapter.isItemSelected();
   }
 

--- a/app/src/main/java/com/freshdigitable/udonroad/TimelineFragment.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/TimelineFragment.java
@@ -22,7 +22,6 @@ import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentActivity;
-import android.support.v4.app.FragmentTransaction;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.support.v7.widget.RecyclerView.AdapterDataObserver;
@@ -34,14 +33,13 @@ import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.animation.Animation;
-import android.view.animation.AnimationUtils;
 
-import com.freshdigitable.udonroad.datastore.SortedCache;
-import com.freshdigitable.udonroad.listitem.OnUserIconClickedListener;
 import com.freshdigitable.udonroad.TimelineAdapter.OnSelectedItemChangeListener;
 import com.freshdigitable.udonroad.databinding.FragmentTimelineBinding;
+import com.freshdigitable.udonroad.datastore.SortedCache;
 import com.freshdigitable.udonroad.datastore.UpdateEvent;
 import com.freshdigitable.udonroad.ffab.IndicatableFFAB.OnIffabItemSelectedListener;
+import com.freshdigitable.udonroad.listitem.OnUserIconClickedListener;
 import com.freshdigitable.udonroad.listitem.StatusView;
 import com.freshdigitable.udonroad.module.InjectionUtil;
 import com.freshdigitable.udonroad.subscriber.ListFetchStrategy;
@@ -515,20 +513,8 @@ public abstract class TimelineFragment<T> extends Fragment implements ItemSelect
 
   @Override
   public Animation onCreateAnimation(int transit, boolean enter, int nextAnim) {
-    if (transit == FragmentTransaction.TRANSIT_FRAGMENT_OPEN) {
-      if (!enter) {
-        return AnimationUtils.makeOutAnimation(getContext(), true);
-      } else {
-        return AnimationUtils.makeInAnimation(getContext(), false);
-      }
-    }
-    if (transit == FragmentTransaction.TRANSIT_FRAGMENT_CLOSE) {
-      if (enter) {
-        return AnimationUtils.makeInAnimation(getContext(), false);
-      } else {
-        return AnimationUtils.makeOutAnimation(getContext(), true);
-      }
-    }
-    return super.onCreateAnimation(transit, enter, nextAnim);
+    final Animation animation = TimelineContainerSwitcher.makeSwitchingAnimation(getContext(), transit, enter);
+    return animation != null ? animation
+        : super.onCreateAnimation(transit, enter, nextAnim);
   }
 }

--- a/app/src/main/java/com/freshdigitable/udonroad/TimelineFragment.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/TimelineFragment.java
@@ -115,7 +115,7 @@ public abstract class TimelineFragment<T> extends Fragment implements ItemSelect
   public View onCreateView(LayoutInflater inflater,
                            @Nullable ViewGroup container,
                            @Nullable Bundle savedInstanceState) {
-    Log.d(TAG, "onCreateView: ");
+    Log.d(TAG, "onCreateView: " + getStoreName());
     if (savedInstanceState != null) {
       isScrolledByUser = savedInstanceState.getBoolean(BUNDLE_IS_SCROLLED_BY_USER);
       stopScroll = savedInstanceState.getBoolean(BUNDLE_STOP_SCROLL);
@@ -128,7 +128,7 @@ public abstract class TimelineFragment<T> extends Fragment implements ItemSelect
 
   @Override
   public void onSaveInstanceState(Bundle outState) {
-    Log.d(TAG, "onSaveInstanceState: ");
+    Log.d(TAG, "onSaveInstanceState: " + getStoreName());
     super.onSaveInstanceState(outState);
     outState.putBoolean(BUNDLE_IS_SCROLLED_BY_USER, isScrolledByUser);
     outState.putBoolean(BUNDLE_STOP_SCROLL, stopScroll);
@@ -138,7 +138,7 @@ public abstract class TimelineFragment<T> extends Fragment implements ItemSelect
 
   @Override
   public void onActivityCreated(@Nullable Bundle savedInstanceState) {
-    Log.d(TAG, "onActivityCreated: ");
+    Log.d(TAG, "onActivityCreated: " + getStoreName());
     super.onActivityCreated(savedInstanceState);
     binding.timeline.setHasFixedSize(true);
     if (timelineDecoration == null) {
@@ -226,6 +226,7 @@ public abstract class TimelineFragment<T> extends Fragment implements ItemSelect
 
   @Override
   public void onStart() {
+    Log.d(TAG, "onStart: " + getStoreName());
     super.onStart();
     if (firstVisibleItemPosOnStop >= 0) {
       tlLayoutManager.scrollToPositionWithOffset(firstVisibleItemPosOnStop, firstVisibleItemTopOnStop);
@@ -323,7 +324,7 @@ public abstract class TimelineFragment<T> extends Fragment implements ItemSelect
 
   @Override
   public void onDetach() {
-    Log.d(TAG, "onDetach: ");
+    Log.d(TAG, "onDetach: " + getStoreName());
     super.onDetach();
     if (firstItemObserver != null) {
       tlAdapter.unregisterAdapterDataObserver(firstItemObserver);

--- a/app/src/main/java/com/freshdigitable/udonroad/UserInfoActivity.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/UserInfoActivity.java
@@ -303,7 +303,9 @@ public class UserInfoActivity extends AppCompatActivity
 
   @Override
   public void showFab() {
-    binding.ffab.show();
+    if (viewPager.getCurrentPage().isStatus()) {
+      binding.ffab.show();
+    }
   }
 
   @Override

--- a/app/src/main/java/com/freshdigitable/udonroad/UserInfoFragment.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/UserInfoFragment.java
@@ -23,6 +23,7 @@ import android.support.annotation.IdRes;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
+import android.support.v4.view.ViewCompat;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.Menu;
@@ -72,7 +73,10 @@ public class UserInfoFragment extends Fragment {
   @Nullable
   @Override
   public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
-    binding = DataBindingUtil.inflate(inflater, R.layout.fragment_user_info, container, false);
+    if (binding == null) {
+      binding = DataBindingUtil.inflate(inflater, R.layout.fragment_user_info, container, false);
+      ViewCompat.setTransitionName(binding.userInfoUserInfoView.getIcon(), UserInfoActivity.getUserIconTransitionName(getUserId()));
+    }
     return binding.getRoot();
   }
 

--- a/app/src/main/java/com/freshdigitable/udonroad/UserInfoPagerFragment.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/UserInfoPagerFragment.java
@@ -45,7 +45,7 @@ import static com.freshdigitable.udonroad.TimelineFragment.UserListFragment;
  *
  * Created by akihit on 2016/06/06.
  */
-public class UserInfoPagerFragment extends Fragment {
+public class UserInfoPagerFragment extends Fragment implements ItemSelectable {
   private static final String TAG = UserInfoPagerFragment.class.getSimpleName();
   private static final String ARGS_USER_ID = "userId";
 
@@ -109,13 +109,17 @@ public class UserInfoPagerFragment extends Fragment {
         public void onPageSelected(int position) {
           Log.d(TAG, "onPageSelected: " + position);
           TimelineFragment fragment = pagerAdapter.getItem(position);
-          if (fragment.isTweetSelected()) {
+          if (fragment.isItemSelected()) {
             ((FabHandleable) activity).showFab();
           } else {
             ((FabHandleable) activity).hideFab();
           }
         }
       });
+      final UserPageInfo currentPage = getCurrentPage();
+      if (currentPage.isStatus()) {
+        ((FabHandleable) activity).showFab();
+      }
     }
   }
 
@@ -140,9 +144,15 @@ public class UserInfoPagerFragment extends Fragment {
     return viewPager;
   }
 
-  public void clearSelectedTweet() {
+  @Override
+  public void clearSelectedItem() {
     final TimelineFragment currentFragment = getCurrentFragment();
-    currentFragment.clearSelectedTweet();
+    currentFragment.clearSelectedItem();
+  }
+
+  @Override
+  public boolean isItemSelected() {
+    return getCurrentFragment().isItemSelected();
   }
 
   private static class PagerAdapter extends FragmentPagerAdapter {

--- a/app/src/main/java/com/freshdigitable/udonroad/UserInfoPagerFragment.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/UserInfoPagerFragment.java
@@ -68,6 +68,12 @@ public class UserInfoPagerFragment extends Fragment implements ItemSelectable {
     InjectionUtil.getComponent(this).inject(this);
   }
 
+  @Override
+  public void onCreate(@Nullable Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setHasOptionsMenu(true);
+  }
+
   @Nullable
   @Override
   public View onCreateView(LayoutInflater inflater,
@@ -138,12 +144,6 @@ public class UserInfoPagerFragment extends Fragment implements ItemSelectable {
     Log.d(TAG, "onStop: ");
     super.onStop();
     viewPager.clearOnPageChangeListeners();
-  }
-
-  @Override
-  public void onDestroyView() {
-    Log.d(TAG, "onDestroyView: ");
-    super.onDestroyView();
   }
 
   @Override

--- a/app/src/main/java/com/freshdigitable/udonroad/UserInfoPagerFragment.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/UserInfoPagerFragment.java
@@ -91,7 +91,9 @@ public class UserInfoPagerFragment extends Fragment implements ItemSelectable {
   public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
     Log.d(TAG, "onViewCreated: ");
     super.onViewCreated(view, savedInstanceState);
-    viewPager = view.findViewById(R.id.user_pager);
+    if (viewPager == null) {
+      viewPager = view.findViewById(R.id.user_pager);
+    }
   }
 
   private PagerAdapter pagerAdapter;

--- a/app/src/main/java/com/freshdigitable/udonroad/UserInfoPagerFragment.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/UserInfoPagerFragment.java
@@ -63,6 +63,7 @@ public class UserInfoPagerFragment extends Fragment implements ItemSelectable {
 
   @Override
   public void onAttach(Context context) {
+    Log.d(TAG, "onAttach: ");
     super.onAttach(context);
     InjectionUtil.getComponent(this).inject(this);
   }
@@ -71,13 +72,17 @@ public class UserInfoPagerFragment extends Fragment implements ItemSelectable {
   @Override
   public View onCreateView(LayoutInflater inflater,
                            @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
-    return inflater.inflate(R.layout.fragment_user_info_pager, container, false);
+    Log.d(TAG, "onCreateView: ");
+    return viewPager == null ?
+        inflater.inflate(R.layout.fragment_user_info_pager, container, false)
+        : viewPager.getRootView();
   }
 
   private ViewPager viewPager;
 
   @Override
   public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
+    Log.d(TAG, "onViewCreated: ");
     super.onViewCreated(view, savedInstanceState);
     viewPager = view.findViewById(R.id.user_pager);
   }
@@ -86,12 +91,15 @@ public class UserInfoPagerFragment extends Fragment implements ItemSelectable {
 
   @Override
   public void onActivityCreated(@Nullable Bundle savedInstanceState) {
+    Log.d(TAG, "onActivityCreated: ");
     super.onActivityCreated(savedInstanceState);
-    pagerAdapter = new PagerAdapter(getChildFragmentManager());
-    for (UserPageInfo page : UserPageInfo.values()) {
-      putToPagerAdapter(page);
+    if (pagerAdapter == null) {
+      pagerAdapter = new PagerAdapter(getChildFragmentManager());
+      for (UserPageInfo page : UserPageInfo.values()) {
+        putToPagerAdapter(page);
+      }
+      viewPager.setAdapter(pagerAdapter);
     }
-    viewPager.setAdapter(pagerAdapter);
   }
 
   private void putToPagerAdapter(@NonNull UserPageInfo page) {
@@ -101,6 +109,7 @@ public class UserInfoPagerFragment extends Fragment implements ItemSelectable {
 
   @Override
   public void onStart() {
+    Log.d(TAG, "onStart: ");
     super.onStart();
     final FragmentActivity activity = getActivity();
     if (activity instanceof FabHandleable) {
@@ -116,10 +125,6 @@ public class UserInfoPagerFragment extends Fragment implements ItemSelectable {
           }
         }
       });
-      final UserPageInfo currentPage = getCurrentPage();
-      if (currentPage.isStatus()) {
-        ((FabHandleable) activity).showFab();
-      }
     }
   }
 
@@ -130,13 +135,21 @@ public class UserInfoPagerFragment extends Fragment implements ItemSelectable {
 
   @Override
   public void onStop() {
+    Log.d(TAG, "onStop: ");
     super.onStop();
     viewPager.clearOnPageChangeListeners();
   }
 
   @Override
   public void onDestroyView() {
+    Log.d(TAG, "onDestroyView: ");
     super.onDestroyView();
+  }
+
+  @Override
+  public void onDetach() {
+    Log.d(TAG, "onDetach: ");
+    super.onDetach();
     viewPager.setAdapter(null);
   }
 

--- a/app/src/main/java/com/freshdigitable/udonroad/UserInfoPagerFragment.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/UserInfoPagerFragment.java
@@ -29,6 +29,7 @@ import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.animation.Animation;
 
 import com.freshdigitable.udonroad.module.InjectionUtil;
 
@@ -260,5 +261,12 @@ public class UserInfoPagerFragment extends Fragment implements ItemSelectable {
     }
 
     public abstract String createTitle(User user);
+  }
+
+  @Override
+  public Animation onCreateAnimation(int transit, boolean enter, int nextAnim) {
+    final Animation animation = TimelineContainerSwitcher.makeSwitchingAnimation(getContext(), transit, enter);
+    return animation != null ? animation
+        : super.onCreateAnimation(transit, enter, nextAnim);
   }
 }

--- a/app/src/main/java/com/freshdigitable/udonroad/UserInfoPagerFragment.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/UserInfoPagerFragment.java
@@ -75,7 +75,7 @@ public class UserInfoPagerFragment extends Fragment implements ItemSelectable {
     Log.d(TAG, "onCreateView: ");
     return viewPager == null ?
         inflater.inflate(R.layout.fragment_user_info_pager, container, false)
-        : viewPager.getRootView();
+        : viewPager;
   }
 
   private ViewPager viewPager;

--- a/app/src/main/java/com/freshdigitable/udonroad/UserInfoView.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/UserInfoView.java
@@ -78,7 +78,6 @@ public class UserInfoView extends RelativeLayout {
     protectedIcon = v.findViewById(R.id.user_protected_icon);
     followingStatus = v.findViewById(R.id.user_following);
     mutedStatus = v.findViewById(R.id.user_muted);
-    ViewCompat.setTransitionName(icon, "user_icon");
   }
 
   public void bindData(User user) {

--- a/app/src/main/res/layout/activity_user_info.xml
+++ b/app/src/main/res/layout/activity_user_info.xml
@@ -92,7 +92,7 @@
         <FrameLayout
             android:id="@+id/userInfo_timeline_container"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
+            android:layout_height="match_parent"
             app:layout_behavior="@string/appbar_scrolling_view_behavior"
             />
         <com.freshdigitable.udonroad.ffab.IndicatableFFAB

--- a/app/src/main/res/layout/activity_user_info.xml
+++ b/app/src/main/res/layout/activity_user_info.xml
@@ -101,6 +101,8 @@
             android:layout_height="wrap_content"
             android:layout_marginBottom="@dimen/iffab_margin_bottom"
             android:layout_gravity="bottom|center_horizontal"
+            android:visibility="invisible"
+            tools:visibility="visible"
             app:menu="@menu/iffab_main"
             />
     </android.support.design.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/fragment_status_detail.xml
+++ b/app/src/main/res/layout/fragment_status_detail.xml
@@ -18,7 +18,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     >
-    <ScrollView
+    <android.support.v4.widget.NestedScrollView
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         >
@@ -42,5 +42,5 @@
                 tools:visibility="visible"
                 />
         </LinearLayout>
-    </ScrollView>
+    </android.support.v4.widget.NestedScrollView>
 </layout>


### PR DESCRIPTION
- [x] `MainActivity`で実装している`TimelineFragment`用のコンテナViewの切り替えロジックを`TimlineContainerSwitcher`クラスに切り出す
- [x] `UserInfoActivity`で`TimelineContainerSwitcher`を使い同等の操作をできるようにする
    - [x] `StatusDetail`から戻ってきた時にFABが表示されない
    - [x] 会話のitem viewが表示されない
    - [x] 会話を表示した後twitter birdが表示されなくなる
    - [x] `StatusDetail`や会話のときはTabを隠す
- [x] `UserInfoActivity`でuser iconをクリックして別のUserInfoへ飛べるようにする refs: #104 
- ~~user icon のアニメーションが途中で引っかからないようにする~~ 次PRへ