### PR TITLE
UserInfoActivityへ遷移する時のアニメーションが滑らかに行われるようにする

### DIFF
--- a/app/src/main/java/com/freshdigitable/udonroad/TimelineAdapter.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/TimelineAdapter.java
@@ -53,6 +53,17 @@ public class TimelineAdapter<T> extends RecyclerView.Adapter<ItemViewHolder> {
   }
 
   @Override
+  public int getItemViewType(int position) {
+    final T t = timelineStore.get(position);
+    if (t instanceof Status) {
+      return ItemViewHolder.TYPE_STATUS;
+    } else if (t instanceof User) {
+      return ItemViewHolder.TYPE_USER;
+    }
+    throw new IllegalStateException();
+  }
+
+  @Override
   public ItemViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
     return new ItemViewHolder(parent, viewType);
   }

--- a/app/src/main/java/com/freshdigitable/udonroad/TimelineFragment.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/TimelineFragment.java
@@ -158,10 +158,24 @@ public abstract class TimelineFragment<T> extends Fragment implements ItemSelect
       requestWorker.setStoreName(getStoreType(), getEntityId() > 0 ? Long.toString(getEntityId()) : null);
       tlAdapter = new TimelineAdapter<>(sortedCache);
       binding.timeline.setAdapter(tlAdapter);
-      fetchTweet(null);
+      if (getUserVisibleHint()) {
+        fetchTweet(null);
+        doneFirstFetch = true;
+      }
     }
     tlAdapter.registerAdapterDataObserver(itemInsertedObserver);
     tlAdapter.registerAdapterDataObserver(createdAtObserver);
+  }
+
+  private boolean doneFirstFetch = false;
+
+  @Override
+  public void setUserVisibleHint(boolean isVisibleToUser) {
+    super.setUserVisibleHint(isVisibleToUser);
+    if (isVisibleToUser && !doneFirstFetch && requestWorker != null) {
+      fetchTweet(null);
+      doneFirstFetch = true;
+    }
   }
 
   private final AdapterDataObserver itemInsertedObserver

--- a/app/src/main/java/com/freshdigitable/udonroad/UserInfoActivity.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/UserInfoActivity.java
@@ -93,7 +93,6 @@ public class UserInfoActivity extends AppCompatActivity
     viewPager = UserInfoPagerFragment.create(userId);
     userInfoAppbarFragment = UserInfoFragment.create(userId);
     getSupportFragmentManager().beginTransaction()
-        .replace(R.id.userInfo_timeline_container, viewPager)
         .replace(R.id.userInfo_appbar_container, userInfoAppbarFragment)
         .commit();
     timelineContainerSwitcher = new TimelineContainerSwitcher(binding.userInfoTimelineContainer, viewPager, binding.ffab);
@@ -171,6 +170,16 @@ public class UserInfoActivity extends AppCompatActivity
       closeTwitterInputView();
     }
     return super.onOptionsItemSelected(item);
+  }
+
+  @Override
+  public void onEnterAnimationComplete() {
+    super.onEnterAnimationComplete();
+    userInfoAppbarFragment.onEnterAnimationComplete();
+    getSupportFragmentManager().beginTransaction()
+        .replace(R.id.userInfo_timeline_container, viewPager)
+        .commitNow();
+    binding.userInfoTabs.setupWithViewPager(viewPager.getViewPager());
   }
 
   public static Intent createIntent(Context context, User user) {
@@ -271,7 +280,9 @@ public class UserInfoActivity extends AppCompatActivity
 
 
   private void setupTabs(@NonNull final TabLayout userInfoTabs, User user) {
-    userInfoTabs.setupWithViewPager(viewPager.getViewPager());
+    if (viewPager.getViewPager() != null) {
+      userInfoTabs.setupWithViewPager(viewPager.getViewPager());
+    }
     updateTabs(userInfoTabs, user);
     subscription = userCache.observeById(getUserId())
         .observeOn(AndroidSchedulers.mainThread())

--- a/app/src/main/java/com/freshdigitable/udonroad/UserInfoFragment.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/UserInfoFragment.java
@@ -83,6 +83,12 @@ public class UserInfoFragment extends Fragment {
   @Inject
   TypedCache<User> userCache;
 
+  void onEnterAnimationComplete() {
+    configRequestWorker.observeFetchRelationship(getUserId())
+        .observeOn(AndroidSchedulers.mainThread())
+        .subscribe(updateRelationship(), e -> {});
+  }
+
   @Override
   public void onStart() {
     super.onStart();
@@ -95,9 +101,6 @@ public class UserInfoFragment extends Fragment {
         .observeOn(AndroidSchedulers.mainThread())
         .subscribe(this::showUserInfo,
             e-> Log.e("UserInfoFragment", "userUpdated: ", e));
-    configRequestWorker.observeFetchRelationship(userId)
-        .observeOn(AndroidSchedulers.mainThread())
-        .subscribe(updateRelationship(), e -> {});
   }
 
   @Override

--- a/app/src/main/java/com/freshdigitable/udonroad/listitem/ItemView.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/listitem/ItemView.java
@@ -28,7 +28,6 @@ import android.widget.TextView;
 
 import com.freshdigitable.udonroad.CombinedScreenNameTextView;
 import com.freshdigitable.udonroad.R;
-import com.freshdigitable.udonroad.media.ThumbnailContainer;
 
 /**
  * StatusViewBase defines how to bind Status and StatusView.
@@ -36,12 +35,9 @@ import com.freshdigitable.udonroad.media.ThumbnailContainer;
  * Created by akihit on 2016/06/28.
  */
 public abstract class ItemView extends RelativeLayout {
-  TextView createdAt;
   ImageView icon;
   CombinedScreenNameTextView names;
   TextView tweet;
-  TextView clientName;
-  ThumbnailContainer thumbnailContainer;
   ReactionContainer reactionContainer;
   final int grid;
   final int selectedColor;
@@ -73,11 +69,8 @@ public abstract class ItemView extends RelativeLayout {
       return;
     }
     names.setNames(item.getUser());
-    createdAt.setText(item.getCreatedTime(getContext()));
     tweet.setText(item.getText());
     reactionContainer.update(item.getStats());
-    thumbnailContainer.bindMediaEntities(item.getMediaCount());
-    clientName.setText(formatString(R.string.tweet_via, item.getSource()));
   }
 
   @CallSuper
@@ -88,9 +81,6 @@ public abstract class ItemView extends RelativeLayout {
     icon.setImageResource(android.R.color.transparent);
     icon.setOnClickListener(null);
     setOnClickListener(null);
-
-    thumbnailContainer.reset();
-    thumbnailContainer.setOnMediaClickListener(null);
   }
 
   String formatString(@StringRes int id, Object... items) {
@@ -100,10 +90,6 @@ public abstract class ItemView extends RelativeLayout {
 
   public ImageView getIcon() {
     return icon;
-  }
-
-  public ThumbnailContainer getThumbnailContainer() {
-    return thumbnailContainer;
   }
 
   public abstract void setSelectedColor();

--- a/app/src/main/java/com/freshdigitable/udonroad/listitem/ListItem.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/listitem/ListItem.java
@@ -16,8 +16,6 @@
 
 package com.freshdigitable.udonroad.listitem;
 
-import android.content.Context;
-
 import java.util.List;
 
 import twitter4j.User;
@@ -31,13 +29,7 @@ public interface ListItem {
 
   CharSequence getText();
 
-  String getCreatedTime(Context context);
-
-  String getSource();
-
   User getUser(); // XXX
-
-  int getMediaCount();
 
   List<Stat> getStats();
 

--- a/app/src/main/java/com/freshdigitable/udonroad/listitem/QuotedStatusView.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/listitem/QuotedStatusView.java
@@ -19,8 +19,10 @@ package com.freshdigitable.udonroad.listitem;
 import android.content.Context;
 import android.util.AttributeSet;
 import android.view.View;
+import android.widget.TextView;
 
 import com.freshdigitable.udonroad.R;
+import com.freshdigitable.udonroad.media.ThumbnailContainer;
 
 /**
  * QuotedStatusView is for quoted tweet in StatusView and StatusDetailFragment.<br>
@@ -28,7 +30,10 @@ import com.freshdigitable.udonroad.R;
  *
  * Created by akihit on 2016/06/26.
  */
-public class QuotedStatusView extends ItemView {
+public class QuotedStatusView extends ItemView implements ThumbnailCapable {
+  TextView createdAt;
+  TextView clientName;
+  ThumbnailContainer thumbnailContainer;
 
   private TwitterListItem.TimeTextStrategy timeStrategy;
 
@@ -61,6 +66,9 @@ public class QuotedStatusView extends ItemView {
     }
     super.bind(item);
     timeStrategy = item.getTimeStrategy();
+    createdAt.setText(item.getCreatedTime(getContext()));
+    thumbnailContainer.bindMediaEntities(item.getMediaCount());
+    clientName.setText(formatString(R.string.tweet_via, item.getSource()));
   }
 
   public void updateTime() {
@@ -81,6 +89,8 @@ public class QuotedStatusView extends ItemView {
   @Override
   public void reset() {
     super.reset();
+    thumbnailContainer.reset();
+    thumbnailContainer.setOnMediaClickListener(null);
     setBackgroundResource(R.drawable.s_rounded_frame_default);
   }
 
@@ -92,5 +102,10 @@ public class QuotedStatusView extends ItemView {
   @Override
   public void setUnselectedColor() {
     setBackgroundResource(R.drawable.s_rounded_frame_default);
+  }
+
+  @Override
+  public ThumbnailContainer getThumbnailContainer() {
+    return thumbnailContainer;
   }
 }

--- a/app/src/main/java/com/freshdigitable/udonroad/listitem/StatusListItem.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/listitem/StatusListItem.java
@@ -271,7 +271,7 @@ public class StatusListItem implements TwitterListItem {
   }
 
   @Override
-  public ListItem getQuotedItem() {
+  public TwitterListItem getQuotedItem() {
     final Status quotedStatus = bindingStatus.getQuotedStatus();
     return quotedStatus != null
         ? new StatusListItem(quotedStatus, TextType.QUOTED) : null;

--- a/app/src/main/java/com/freshdigitable/udonroad/listitem/StatusViewImageHelper.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/listitem/StatusViewImageHelper.java
@@ -20,6 +20,7 @@ import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.drawable.Drawable;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.support.v4.content.ContextCompat;
 import android.widget.ImageView;
 
@@ -59,14 +60,14 @@ public class StatusViewImageHelper {
     unloadQuotedStatusImages(itemView.getQuotedStatusView());
   }
 
-  private static void loadUserIcon(User user, final long tagId, final StatusView itemView) {
+  static void loadUserIcon(User user, final long tagId, final ItemView itemView) {
     getRequest(itemView.getContext(), user.getProfileImageURLHttps(), tagId)
         .resizeDimen(R.dimen.tweet_user_icon, R.dimen.tweet_user_icon)
         .placeholder(R.drawable.ic_person_outline_black)
         .into(itemView.getIcon());
   }
 
-  private static void unloadUserIcon(StatusView itemView) {
+  static void unloadUserIcon(ItemView itemView) {
     unloadImage(itemView.getIcon());
   }
 
@@ -121,7 +122,7 @@ public class StatusViewImageHelper {
     itemView.getRtUser().setText("");
   }
 
-  private static void loadMediaView(final TwitterListItem item, final ItemView statusView) {
+  private static void loadMediaView(final TwitterListItem item, final ThumbnailCapable statusView) {
     final MediaEntity[] mediaEntities = item.getMediaEntities();
     final ThumbnailContainer thumbnailContainer = statusView.getThumbnailContainer();
     thumbnailContainer.bindMediaEntities(mediaEntities);
@@ -148,7 +149,7 @@ public class StatusViewImageHelper {
     }
   }
 
-  private static void unloadMediaView(ItemView statusView) {
+  private static void unloadMediaView(ThumbnailCapable statusView) {
     final ThumbnailContainer thumbnailContainer = statusView.getThumbnailContainer();
     final int thumbCount = thumbnailContainer.getThumbCount();
     for (int i=0; i<thumbCount;i++) {
@@ -157,7 +158,10 @@ public class StatusViewImageHelper {
     }
   }
 
-  private static void loadQuotedStatusImages(TwitterListItem item, QuotedStatusView quotedStatusView) {
+  private static void loadQuotedStatusImages(TwitterListItem item, @Nullable QuotedStatusView quotedStatusView) {
+    if (quotedStatusView == null) {
+      return;
+    }
     final ListItem quotedStatus = item.getQuotedItem();
     if (quotedStatus == null) {
       return;
@@ -170,7 +174,10 @@ public class StatusViewImageHelper {
     loadMediaView((TwitterListItem) quotedStatus, quotedStatusView);
   }
 
-  private static void unloadQuotedStatusImages(QuotedStatusView quotedStatusView) {
+  private static void unloadQuotedStatusImages(@Nullable QuotedStatusView quotedStatusView) {
+    if (quotedStatusView == null) {
+      return;
+    }
     unloadImage(quotedStatusView.getIcon());
     unloadMediaView(quotedStatusView);
   }

--- a/app/src/main/java/com/freshdigitable/udonroad/listitem/ThumbnailCapable.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/listitem/ThumbnailCapable.java
@@ -16,38 +16,12 @@
 
 package com.freshdigitable.udonroad.listitem;
 
-import android.content.Context;
-import android.support.annotation.Nullable;
-
-import twitter4j.MediaEntity;
-import twitter4j.User;
+import com.freshdigitable.udonroad.media.ThumbnailContainer;
 
 /**
- * Created by akihit on 2017/06/16.
+ * Created by akihit on 2017/07/09.
  */
 
-public interface TwitterListItem extends ListItem {
-  boolean isRetweet();
-
-  String getCreatedTime(Context context);
-
-  String getSource();
-
-  int getMediaCount();
-
-  User getRetweetUser();
-
-  @Nullable
-  TwitterListItem getQuotedItem();
-
-  @Nullable
-  TimeTextStrategy getTimeStrategy();
-
-  MediaEntity[] getMediaEntities();
-
-  boolean isPossiblySensitive();
-
-  interface TimeTextStrategy {
-    String getCreatedTime(Context context);
-  }
+interface ThumbnailCapable {
+  ThumbnailContainer getThumbnailContainer();
 }

--- a/app/src/main/java/com/freshdigitable/udonroad/listitem/TwitterItemView.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/listitem/TwitterItemView.java
@@ -16,38 +16,12 @@
 
 package com.freshdigitable.udonroad.listitem;
 
-import android.content.Context;
-import android.support.annotation.Nullable;
-
-import twitter4j.MediaEntity;
-import twitter4j.User;
-
 /**
- * Created by akihit on 2017/06/16.
+ * Created by akihit on 2017/07/09.
  */
 
-public interface TwitterListItem extends ListItem {
-  boolean isRetweet();
+public interface TwitterItemView {
+  void update(TwitterListItem item);
 
-  String getCreatedTime(Context context);
-
-  String getSource();
-
-  int getMediaCount();
-
-  User getRetweetUser();
-
-  @Nullable
-  TwitterListItem getQuotedItem();
-
-  @Nullable
-  TimeTextStrategy getTimeStrategy();
-
-  MediaEntity[] getMediaEntities();
-
-  boolean isPossiblySensitive();
-
-  interface TimeTextStrategy {
-    String getCreatedTime(Context context);
-  }
+  void updateTime();
 }

--- a/app/src/main/java/com/freshdigitable/udonroad/listitem/UserItemView.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/listitem/UserItemView.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2017. Matsuda, Akihit (akihito104)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.freshdigitable.udonroad.listitem;
+
+import android.content.Context;
+import android.util.AttributeSet;
+import android.view.View;
+
+import com.freshdigitable.udonroad.R;
+
+/**
+ * Created by akihit on 2017/07/09.
+ */
+
+public class UserItemView extends ItemView implements TwitterItemView {
+  public UserItemView(Context context) {
+    this(context, null);
+  }
+
+  public UserItemView(Context context, AttributeSet attrs) {
+    this(context, attrs, 0);
+  }
+
+  public UserItemView(Context context, AttributeSet attrs, int defStyleAttr) {
+    super(context, attrs, defStyleAttr);
+    final View v = View.inflate(context, R.layout.view_user_list, this);
+    icon = v.findViewById(R.id.tl_icon);
+    names = v.findViewById(R.id.tl_names);
+    tweet = v.findViewById(R.id.tl_tweet);
+    reactionContainer = v.findViewById(R.id.tl_reaction_container);
+  }
+
+  @Override
+  public void update(TwitterListItem item) {
+    tweet.setText(item.getText());
+  }
+
+  @Override
+  public void updateTime() {}
+
+  @Override
+  public void setSelectedColor() {}
+
+  @Override
+  public void setUnselectedColor() {}
+}

--- a/app/src/main/java/com/freshdigitable/udonroad/listitem/UserListItem.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/listitem/UserListItem.java
@@ -129,7 +129,7 @@ public class UserListItem implements TwitterListItem {
   }
 
   @Override
-  public ListItem getQuotedItem() {
+  public TwitterListItem getQuotedItem() {
     return null;
   }
 

--- a/app/src/main/java/com/freshdigitable/udonroad/media/MediaViewActivity.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/media/MediaViewActivity.java
@@ -46,7 +46,7 @@ import com.freshdigitable.udonroad.databinding.ActivityMediaViewBinding;
 import com.freshdigitable.udonroad.datastore.MediaCache;
 import com.freshdigitable.udonroad.datastore.TypedCache;
 import com.freshdigitable.udonroad.ffab.IndicatableFFAB;
-import com.freshdigitable.udonroad.listitem.ListItem;
+import com.freshdigitable.udonroad.listitem.TwitterListItem;
 import com.freshdigitable.udonroad.module.InjectionUtil;
 import com.freshdigitable.udonroad.subscriber.StatusRequestWorker;
 
@@ -76,11 +76,11 @@ public class MediaViewActivity extends AppCompatActivity implements View.OnClick
   StatusRequestWorker statusRequestWorker;
   private MediaPagerAdapter mediaPagerAdapter;
 
-  public static Intent create(@NonNull Context context, @NonNull ListItem item) {
+  public static Intent create(@NonNull Context context, @NonNull TwitterListItem item) {
     return create(context, item, 0);
   }
 
-  public static Intent create(@NonNull Context context, @NonNull ListItem item, int startPage) {
+  public static Intent create(@NonNull Context context, @NonNull TwitterListItem item, int startPage) {
     if (item.getMediaCount() < startPage + 1) {
       throw new IllegalArgumentException(
           "startPage number exceeded ExtendedMediaEntities length: " + startPage);
@@ -92,7 +92,7 @@ public class MediaViewActivity extends AppCompatActivity implements View.OnClick
     return intent;
   }
 
-  public static void start(@NonNull Context context, @NonNull ListItem item, int startPage) {
+  public static void start(@NonNull Context context, @NonNull TwitterListItem item, int startPage) {
     final Intent intent = create(context, item, startPage);
     context.startActivity(intent);
   }

--- a/app/src/main/res/layout/view_status.xml
+++ b/app/src/main/res/layout/view_status.xml
@@ -148,9 +148,9 @@
         app:thumbCount="4"
         />
 
-    <com.freshdigitable.udonroad.listitem.QuotedStatusView
-        android:id="@+id/tl_quoted"
-        android:layout_width="wrap_content"
+    <View
+        android:id="@+id/tl_quoted_placeholder"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/grid_margin"
         android:layout_below="@id/tl_via"

--- a/app/src/main/res/layout/view_user_info.xml
+++ b/app/src/main/res/layout/view_user_info.xml
@@ -168,6 +168,7 @@
         android:layout_alignLeft="@+id/user_screen_name"
         android:layout_alignStart="@id/user_screen_name"
         android:textSize="@dimen/tweet_main_size"
+        android:textColor="@color/text_primary_inverse"
         android:paddingStart="@dimen/grid_margin"
         android:paddingLeft="@dimen/grid_margin"
         android:paddingEnd="@dimen/grid_margin"
@@ -176,7 +177,7 @@
         />
 
     <com.freshdigitable.udonroad.IconAttachedTextView
-        android:id="@+id/user_url"
+        android:id="@+id/user_location"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/grid_margin_detail"
@@ -184,26 +185,27 @@
         android:layout_alignLeft="@+id/user_screen_name"
         android:layout_alignStart="@id/user_screen_name"
         android:visibility="gone"
-        app:icon="@drawable/ic_link"
-        app:paddingEnd="@dimen/grid_margin"
-        app:tintIcon="#000"
-        tools:text="www.user-web.com"
-        tools:visibility="visible"
-        />
-
-    <com.freshdigitable.udonroad.IconAttachedTextView
-        android:id="@+id/user_location"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/grid_margin_detail"
-        android:layout_below="@+id/user_url"
-        android:layout_alignLeft="@+id/user_screen_name"
-        android:layout_alignStart="@id/user_screen_name"
-        android:visibility="gone"
+        android:textColor="@color/text_primary_inverse"
         app:icon="@drawable/ic_location_on"
         app:paddingEnd="@dimen/grid_margin"
         app:tintIcon="#000"
         tools:text="user location"
+        tools:visibility="visible"
+        />
+
+    <com.freshdigitable.udonroad.IconAttachedTextView
+        android:id="@+id/user_url"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/grid_margin_detail"
+        android:layout_below="@+id/user_location"
+        android:layout_alignLeft="@+id/user_screen_name"
+        android:layout_alignStart="@id/user_screen_name"
+        android:visibility="gone"
+        app:icon="@drawable/ic_link"
+        app:paddingEnd="@dimen/grid_margin"
+        app:tintIcon="#000"
+        tools:text="www.user-web.com"
         tools:visibility="visible"
         />
 </merge>

--- a/app/src/main/res/layout/view_user_list.xml
+++ b/app/src/main/res/layout/view_user_list.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2017. Matsuda, Akihit (akihito104)
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
+       xmlns:tools="http://schemas.android.com/tools"
+       tools:parentTag="android.widget.RelativeLayout"
+       android:layout_width="match_parent"
+       android:layout_height="match_parent"
+    >
+    <com.freshdigitable.udonroad.RoundedCornerImageView
+        android:id="@+id/tl_icon"
+        android:layout_width="@dimen/tweet_user_icon"
+        android:layout_height="@dimen/tweet_user_icon"
+        android:layout_below="@+id/tl_rt_user"
+        android:layout_alignParentLeft="true"
+        android:layout_alignParentStart="true"
+        android:contentDescription="@string/desc_icon"
+        android:layout_marginRight="@dimen/grid_margin"
+        android:layout_marginEnd="@dimen/grid_margin"
+        />
+
+    <com.freshdigitable.udonroad.CombinedScreenNameTextView
+        android:id="@+id/tl_names"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginRight="@dimen/grid_margin"
+        android:layout_marginEnd="@dimen/grid_margin"
+        android:layout_toRightOf="@id/tl_icon"
+        android:layout_toEndOf="@id/tl_icon"
+        android:textSize="@dimen/tweet_small_fontsize"
+        android:lines="1"
+        android:ellipsize="end"
+        tools:text="ScreenName \@name"
+        />
+
+    <TextView
+        android:id="@+id/tl_tweet"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_below="@+id/tl_names"
+        android:layout_toRightOf="@+id/tl_icon"
+        android:layout_toEndOf="@+id/tl_icon"
+        android:textSize="@dimen/tweet_main_size"
+        tools:text="Tweet"
+        />
+
+    <com.freshdigitable.udonroad.listitem.TwitterReactionContainer
+        android:id="@+id/tl_reaction_container"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:layout_below="@+id/tl_tweet"
+        android:layout_toRightOf="@+id/tl_icon"
+        android:layout_toEndOf="@+id/tl_icon"
+        android:layout_marginTop="@dimen/grid_margin"
+        android:layout_marginRight="@dimen/grid_margin_detail"
+        android:layout_marginEnd="@dimen/grid_margin_detail"
+        />
+</merge>


### PR DESCRIPTION
- [x] 不要なViewを作らないようにする
    - [x] User用のItemViewを作る
    - [x] QuotedStatusViewは必要になってから作る
- [x] 最初に表示されないページのデータ取得をやめる
- ~~データを取得してから保存するまでの処理を最適化する~~
- [x] Transitアニメーション終了後にタイムラインを読み込む