### PR TITLE
アカウント切り替え機能を実装する

### DIFF
--- a/app/src/androidTest/java/com/freshdigitable/udonroad/AccountScenarioInstTest.java
+++ b/app/src/androidTest/java/com/freshdigitable/udonroad/AccountScenarioInstTest.java
@@ -37,7 +37,6 @@ import android.support.test.espresso.util.HumanReadables;
 import android.support.test.rule.ActivityTestRule;
 import android.support.test.runner.AndroidJUnit4;
 import android.support.test.runner.lifecycle.Stage;
-import android.support.v4.widget.DrawerLayout;
 import android.support.v7.app.AppCompatActivity;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -93,7 +92,7 @@ import static org.mockito.Mockito.when;
  * Created by akihit on 2017/09/11.
  */
 @RunWith(AndroidJUnit4.class)
-public class NavDrawerInstTest extends TimelineInstTestBase {
+public class AccountScenarioInstTest extends TimelineInstTestBase {
   @Rule
   public final IntentsTestRule<MainActivity> rule
       = new IntentsTestRule<>(MainActivity.class, false, false);
@@ -379,20 +378,12 @@ public class NavDrawerInstTest extends TimelineInstTestBase {
 
   @NonNull
   private IdlingResource getOpenDrawerIdlingResource() {
-    return IdlingResourceUtil.getSimpleIdlingResource("open drawer", () -> {
-      final DrawerLayout drawerLayout = rule.getActivity().findViewById(R.id.nav_drawer_layout);
-      final View drawer = rule.getActivity().findViewById(R.id.nav_drawer);
-      return drawerLayout.isDrawerOpen(drawer);
-    });
+    return IdlingResourceUtil.getOpenDrawerIdlingResource(rule.getActivity());
   }
 
   @NonNull
   private IdlingResource getCloseDrawerIdlingResource() {
-    return IdlingResourceUtil.getSimpleIdlingResource("close drawer", () -> {
-      final DrawerLayout drawerLayout = rule.getActivity().findViewById(R.id.nav_drawer_layout);
-      final View drawer = rule.getActivity().findViewById(R.id.nav_drawer);
-      return !drawerLayout.isDrawerOpen(drawer);
-    });
+    return IdlingResourceUtil.getCloseDrawerIdlingResource(rule.getActivity());
   }
 
   private static Matcher<View> isDefaultNavMenu() {

--- a/app/src/androidTest/java/com/freshdigitable/udonroad/MockAppComponent.java
+++ b/app/src/androidTest/java/com/freshdigitable/udonroad/MockAppComponent.java
@@ -16,6 +16,7 @@
 
 package com.freshdigitable.udonroad;
 
+import com.freshdigitable.udonroad.datastore.AppSettingStoreTest;
 import com.freshdigitable.udonroad.module.AppComponent;
 import com.freshdigitable.udonroad.module.DataStoreModule;
 import com.freshdigitable.udonroad.module.TwitterApiModule;
@@ -38,4 +39,6 @@ public interface MockAppComponent extends AppComponent {
   void inject(UserInfoActivityInstTest.Base userInfoActivityInstTest);
 
   void inject(OAuthActivityInstTest.Base oAuthActivityInstTest);
+
+  void inject(AppSettingStoreTest appSettingStoreTest);
 }

--- a/app/src/androidTest/java/com/freshdigitable/udonroad/MockTwitterApiModule.java
+++ b/app/src/androidTest/java/com/freshdigitable/udonroad/MockTwitterApiModule.java
@@ -62,6 +62,8 @@ public class MockTwitterApiModule extends TwitterApiModule {
         @Override
         public void connectUserStream(UserStreamListener listener) {
           userStreamListener = listener;
+          twitterStream.addListener(listener);
+          twitterStream.user();
         }
       };
     }

--- a/app/src/androidTest/java/com/freshdigitable/udonroad/NavDrawerInstTest.java
+++ b/app/src/androidTest/java/com/freshdigitable/udonroad/NavDrawerInstTest.java
@@ -255,6 +255,7 @@ public class NavDrawerInstTest extends TimelineInstTestBase {
     final User user = UserUtil.builder(100L, "userAA").name("user AA").build();
     when(twitter.getId()).thenReturn(100L);
     when(twitter.showUser(100L)).thenReturn(user);
+    when(twitter.verifyCredentials()).thenReturn(user);
 
     intending(hasData(Uri.parse(authorizationUrl)))
         .respondWith(new Instrumentation.ActivityResult(Activity.RESULT_OK, new Intent()));

--- a/app/src/androidTest/java/com/freshdigitable/udonroad/NavDrawerInstTest.java
+++ b/app/src/androidTest/java/com/freshdigitable/udonroad/NavDrawerInstTest.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright (c) 2017. Matsuda, Akihit (akihito104)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.freshdigitable.udonroad;
+
+import android.support.annotation.IdRes;
+import android.support.annotation.NonNull;
+import android.support.design.widget.NavigationView;
+import android.support.test.espresso.Espresso;
+import android.support.test.espresso.IdlingResource;
+import android.support.test.espresso.matcher.BoundedMatcher;
+import android.support.test.rule.ActivityTestRule;
+import android.support.test.runner.AndroidJUnit4;
+import android.support.v4.widget.DrawerLayout;
+import android.support.v7.app.AppCompatActivity;
+import android.view.Menu;
+import android.view.MenuItem;
+import android.view.View;
+
+import com.freshdigitable.udonroad.util.IdlingResourceUtil;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import twitter4j.TwitterException;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static com.freshdigitable.udonroad.util.PerformUtil.closeDrawerNavigation;
+import static com.freshdigitable.udonroad.util.PerformUtil.openDrawerNavigation;
+import static org.hamcrest.CoreMatchers.not;
+
+/**
+ * Created by akihit on 2017/09/11.
+ */
+@RunWith(AndroidJUnit4.class)
+public class NavDrawerInstTest extends TimelineInstTestBase {
+  private final ActivityTestRule<MainActivity> rule
+      = new ActivityTestRule<>(MainActivity.class, false, false);
+
+  @Test
+  public void openDrawer() {
+    onView(withId(R.id.nav_header_account)).check(matches(not(isDisplayed())));
+    openDrawerNavigation();
+
+    final IdlingResource ir = getOpenDrawerIdlingResource();
+    try {
+      Espresso.registerIdlingResources(ir);
+      onView(withId(R.id.nav_header_account)).check(matches(isDisplayed()));
+      onView(withId(R.id.nav_drawer)).check(matches(isDefaultNavMenu()));
+    } finally {
+      Espresso.unregisterIdlingResources(ir);
+    }
+  }
+
+  @Test
+  public void clickAccountAndShownAddAccount() {
+    openDrawerNavigation();
+
+    final IdlingResource ir = getOpenDrawerIdlingResource();
+    try {
+      Espresso.registerIdlingResources(ir);
+      onView(withId(R.id.nav_header_account)).check(matches(isDisplayed())).perform(click());
+      onView(withId(R.id.nav_drawer)).check(matches(isSelectAccountMenu()));
+    } finally {
+      Espresso.unregisterIdlingResources(ir);
+    }
+  }
+
+  @Test
+  public void closeAddAccountWithBackButton() {
+    openDrawerNavigation();
+
+    final IdlingResource ir = getOpenDrawerIdlingResource();
+    try {
+      Espresso.registerIdlingResources(ir);
+      onView(withId(R.id.nav_header_account)).check(matches(isDisplayed())).perform(click());
+      onView(withId(R.id.nav_drawer)).check(matches(isSelectAccountMenu()));
+
+      Espresso.pressBack();
+      onView(withId(R.id.nav_drawer)).check(matches(isDefaultNavMenu()));
+    } finally {
+      Espresso.unregisterIdlingResources(ir);
+    }
+  }
+
+  @Test
+  public void clickAccountAndReopen_then_shownDefaultMenu() {
+    openDrawerNavigation();
+
+    final IdlingResource ir = getOpenDrawerIdlingResource();
+    try {
+      Espresso.registerIdlingResources(ir);
+      onView(withId(R.id.nav_header_account)).check(matches(isDisplayed())).perform(click());
+      onView(withId(R.id.nav_drawer)).check(matches(isSelectAccountMenu()));
+    } finally {
+      Espresso.unregisterIdlingResources(ir);
+    }
+
+    closeDrawerNavigation();
+
+    final IdlingResource closeIR = getCloseDrawerIdlingResource();
+    try {
+      Espresso.registerIdlingResources(closeIR);
+      onView(withId(R.id.nav_header_account)).check(matches(not(isDisplayed())));
+    } finally {
+      Espresso.unregisterIdlingResources(closeIR);
+    }
+
+    openDrawerNavigation();
+
+    try {
+      Espresso.registerIdlingResources(ir);
+      onView(withId(R.id.nav_drawer)).check(matches(isDefaultNavMenu()));
+    } finally {
+      Espresso.unregisterIdlingResources(ir);
+    }
+  }
+
+  @NonNull
+  private IdlingResource getOpenDrawerIdlingResource() {
+    return IdlingResourceUtil.getSimpleIdlingResource("open drawer", () -> {
+      final DrawerLayout drawerLayout = rule.getActivity().findViewById(R.id.nav_drawer_layout);
+      final View drawer = rule.getActivity().findViewById(R.id.nav_drawer);
+      return drawerLayout.isDrawerOpen(drawer);
+    });
+  }
+
+  @NonNull
+  private IdlingResource getCloseDrawerIdlingResource() {
+    return IdlingResourceUtil.getSimpleIdlingResource("close drawer", () -> {
+      final DrawerLayout drawerLayout = rule.getActivity().findViewById(R.id.nav_drawer_layout);
+      final View drawer = rule.getActivity().findViewById(R.id.nav_drawer);
+      return !drawerLayout.isDrawerOpen(drawer);
+    });
+  }
+
+  private static Matcher<View> isDefaultNavMenu() {
+    return new BoundedMatcher<View, NavigationView>(NavigationView.class) {
+      @Override
+      protected boolean matchesSafely(NavigationView item) {
+        final Menu menu = item.getMenu();
+        return checkMenuItemVisibility(menu, R.id.drawer_menu_home, true)
+            && checkMenuItemVisibility(menu, R.id.drawer_menu_lists, true)
+            && checkMenuItemVisibility(menu, R.id.drawer_menu_license, true)
+            && checkMenuItemVisibility(menu, R.id.drawer_menu_add_account, false);
+      }
+
+      @Override
+      public void describeTo(Description description) {}
+    };
+  }
+
+  private static Matcher<View> isSelectAccountMenu() {
+    return new BoundedMatcher<View, NavigationView>(NavigationView.class) {
+      @Override
+      protected boolean matchesSafely(NavigationView item) {
+        final Menu menu = item.getMenu();
+        return checkMenuItemVisibility(menu, R.id.drawer_menu_home, false)
+            && checkMenuItemVisibility(menu, R.id.drawer_menu_lists, false)
+            && checkMenuItemVisibility(menu, R.id.drawer_menu_license, false)
+            && checkMenuItemVisibility(menu, R.id.drawer_menu_add_account, true);
+      }
+
+      @Override
+      public void describeTo(Description description) {}
+    };
+  }
+
+  private static boolean checkMenuItemVisibility(Menu menu, @IdRes int menuId, boolean visible) {
+    final MenuItem item = menu.findItem(menuId);
+    if (visible) {
+      return item != null && item.isVisible();
+    } else {
+      return item == null || !item.isVisible();
+    }
+  }
+
+  @Override
+  protected int setupTimeline() throws TwitterException {
+    return 0;
+  }
+
+  @Override
+  protected ActivityTestRule<? extends AppCompatActivity> getRule() {
+    return rule;
+  }
+}

--- a/app/src/androidTest/java/com/freshdigitable/udonroad/NavDrawerInstTest.java
+++ b/app/src/androidTest/java/com/freshdigitable/udonroad/NavDrawerInstTest.java
@@ -49,6 +49,7 @@ import static android.support.test.espresso.action.ViewActions.click;
 import static android.support.test.espresso.assertion.ViewAssertions.matches;
 import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
 import static com.freshdigitable.udonroad.util.IdlingResourceUtil.getActivityStageIdlingResource;
 import static com.freshdigitable.udonroad.util.IdlingResourceUtil.runWithIdlingResource;
 import static com.freshdigitable.udonroad.util.PerformUtil.closeDrawerNavigation;
@@ -96,8 +97,10 @@ public class NavDrawerInstTest extends TimelineInstTestBase {
 
     onView(withId(R.id.nav_drawer)).perform(NavigationViewActions.navigateTo(R.id.drawer_menu_add_account));
     runWithIdlingResource(
-        getActivityStageIdlingResource("launch OAuth", OAuthActivity.class, Stage.RESUMED), () ->
-            onView(withId(R.id.oauth_pin)).check(matches(isDisplayed())));
+        getActivityStageIdlingResource("launch OAuth", OAuthActivity.class, Stage.RESUMED), () -> {
+          onView(withId(R.id.oauth_pin)).check(matches(isDisplayed()));
+          onView(withText(R.string.title_add_account)).check(matches(isDisplayed()));
+        });
 
     InstrumentationRegistry.getInstrumentation().runOnMainSync(() -> {
       final Activity activity = IdlingResourceUtil.findActivityByStage(OAuthActivity.class, Stage.RESUMED);

--- a/app/src/androidTest/java/com/freshdigitable/udonroad/NavDrawerInstTest.java
+++ b/app/src/androidTest/java/com/freshdigitable/udonroad/NavDrawerInstTest.java
@@ -70,6 +70,8 @@ import static com.freshdigitable.udonroad.util.PerformUtil.openDrawerNavigation;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.Matchers.allOf;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
@@ -145,6 +147,8 @@ public class NavDrawerInstTest extends TimelineInstTestBase {
         getActivityStageIdlingResource("launch Main", MainActivity.class, Stage.RESUMED), () ->
             onView(withId(R.id.main_toolbar)).check(matches(isDisplayed())));
 
+    verify(twitterStream, times(1)).user();
+
     InstrumentationRegistry.getInstrumentation().runOnMainSync(() -> {
       final Activity mainActivity = IdlingResourceUtil.findActivityByStage(MainActivity.class, Stage.RESUMED);
       if (mainActivity != null) {
@@ -197,6 +201,8 @@ public class NavDrawerInstTest extends TimelineInstTestBase {
     onView(withId(R.id.nav_drawer)).perform(navigateWithTitle());
     runWithIdlingResource(getCloseDrawerIdlingResource(), () ->
         AssertionUtil.checkMainActivityTitle(R.string.title_home));
+
+    verify(twitterStream, times(2)).user();
 
     openDrawerNavigation();
     final User userASub = UserUtil.createUserAsub();

--- a/app/src/androidTest/java/com/freshdigitable/udonroad/OAuthActivityInstTest.java
+++ b/app/src/androidTest/java/com/freshdigitable/udonroad/OAuthActivityInstTest.java
@@ -26,6 +26,7 @@ import org.mockito.ArgumentMatchers;
 import javax.inject.Inject;
 
 import twitter4j.Twitter;
+import twitter4j.TwitterStream;
 import twitter4j.auth.AccessToken;
 import twitter4j.auth.RequestToken;
 
@@ -175,6 +176,8 @@ public class OAuthActivityInstTest {
     AppSettingStore appSetting;
     @Inject
     Twitter twitter;
+    @Inject
+    TwitterStream twitterStream;
 
     @Before
     @CallSuper
@@ -194,6 +197,7 @@ public class OAuthActivityInstTest {
     @CallSuper
     public void tearDown() throws Exception {
       reset(twitter);
+      reset(twitterStream);
       tearDownActivity();
       StorageUtil.checkAllRealmInstanceCleared();
     }

--- a/app/src/androidTest/java/com/freshdigitable/udonroad/OAuthActivityInstTest.java
+++ b/app/src/androidTest/java/com/freshdigitable/udonroad/OAuthActivityInstTest.java
@@ -49,10 +49,13 @@ import static com.freshdigitable.udonroad.util.AssertionUtil.checkMainActivityTi
 import static com.freshdigitable.udonroad.util.StatusViewMatcher.ofQuotedStatusView;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
@@ -92,6 +95,7 @@ public class OAuthActivityInstTest {
 
     @Test
     public void resumeWithValidToken() throws Exception {
+      verify(twitter, times(0)).setOAuthAccessToken(any(AccessToken.class));
       intending(hasData(Uri.parse(authorizationUrl)))
           .respondWith(new Instrumentation.ActivityResult(Activity.RESULT_OK, new Intent()));
       onView(withId(R.id.oauth_start)).perform(click());
@@ -119,6 +123,7 @@ public class OAuthActivityInstTest {
           appSetting.close();
         }
       });
+       verify(twitter, times(1)).setOAuthAccessToken(any(AccessToken.class));
     }
 
     @Test

--- a/app/src/androidTest/java/com/freshdigitable/udonroad/OwnedListInstTest.java
+++ b/app/src/androidTest/java/com/freshdigitable/udonroad/OwnedListInstTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2017. Matsuda, Akihit (akihito104)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.freshdigitable.udonroad;
+
+import android.support.annotation.NonNull;
+import android.support.test.espresso.Espresso;
+import android.support.test.espresso.contrib.NavigationViewActions;
+import android.support.test.rule.ActivityTestRule;
+import android.support.test.runner.AndroidJUnit4;
+import android.support.v7.app.AppCompatActivity;
+import android.support.v7.widget.RecyclerView;
+
+import com.freshdigitable.udonroad.listitem.UserItemView;
+import com.freshdigitable.udonroad.util.AssertionUtil;
+import com.freshdigitable.udonroad.util.PerformUtil;
+import com.freshdigitable.udonroad.util.TwitterResponseMock;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.Callable;
+
+import twitter4j.PagableResponseList;
+import twitter4j.Paging;
+import twitter4j.ResponseList;
+import twitter4j.Status;
+import twitter4j.TwitterException;
+import twitter4j.User;
+import twitter4j.UserList;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
+import static com.freshdigitable.udonroad.util.IdlingResourceUtil.getOpenDrawerIdlingResource;
+import static com.freshdigitable.udonroad.util.IdlingResourceUtil.getSimpleIdlingResource;
+import static com.freshdigitable.udonroad.util.IdlingResourceUtil.runWithIdlingResource;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+
+/**
+ * Created by akihit on 2017/09/16.
+ */
+@RunWith(AndroidJUnit4.class)
+public class OwnedListInstTest extends TimelineInstTestBase {
+  @Rule
+  public ActivityTestRule<MainActivity> rule
+      = new ActivityTestRule<>(MainActivity.class, false, false);
+
+  @Test
+  public void showOwnedList() {
+    PerformUtil.openDrawerNavigation();
+    runWithIdlingResource(getOpenDrawerIdlingResource(rule.getActivity()), () ->
+        onView(withId(R.id.nav_header_account)).check(matches(isDisplayed()))
+    );
+
+    onView(withId(R.id.nav_drawer)).perform(NavigationViewActions.navigateTo(R.id.drawer_menu_lists));
+    runWithIdlingResource(getSimpleIdlingResource("show lists", isTimelineLoaded()), () -> {
+      AssertionUtil.checkMainActivityTitle(R.string.title_owned_list);
+      onView(withText("list1")).check(matches(isDisplayed()));
+    });
+
+    Espresso.pressBack();
+    runWithIdlingResource(getSimpleIdlingResource("show home", isTimelineLoaded()), () ->
+        AssertionUtil.checkMainActivityTitle(R.string.title_home));
+  }
+
+  @Test
+  public void showTimelineFromOwnedList() {
+    PerformUtil.openDrawerNavigation();
+    runWithIdlingResource(getOpenDrawerIdlingResource(rule.getActivity()), () ->
+        onView(withId(R.id.nav_header_account)).check(matches(isDisplayed()))
+    );
+
+    onView(withId(R.id.nav_drawer)).perform(NavigationViewActions.navigateTo(R.id.drawer_menu_lists));
+    runWithIdlingResource(getSimpleIdlingResource("show lists", isTimelineLoaded()), () -> {
+      AssertionUtil.checkMainActivityTitle(R.string.title_owned_list);
+      onView(withText("list1")).check(matches(isDisplayed()));
+    });
+
+    PerformUtil.selectItemViewAt(0, UserItemView.class);
+    runWithIdlingResource(getSimpleIdlingResource("show listTL", isTimelineLoaded()), () -> {
+      AssertionUtil.checkMainActivityTitle("list0");
+    });
+
+    Espresso.pressBack();
+    runWithIdlingResource(getSimpleIdlingResource("show lists", isTimelineLoaded()), () -> {
+      AssertionUtil.checkMainActivityTitle(R.string.title_owned_list);
+      onView(withText("list0")).check(matches(isDisplayed()));
+    });
+  }
+
+  @NonNull
+  private Callable<Boolean> isTimelineLoaded() {
+    return () -> {
+      final RecyclerView timeline = rule.getActivity().findViewById(R.id.timeline);
+      final int childCount = timeline.getLayoutManager().getChildCount();
+      return childCount > 0;
+    };
+  }
+
+  @Override
+  protected void setupConfig(User loginUser) throws Exception {
+    super.setupConfig(loginUser);
+    final PagableResponseList<UserList> userListResponse = TwitterResponseMock.createUserListResponse(20);
+    when(twitter.getUserListsOwnerships(anyLong(), anyInt(), anyLong())).thenReturn(userListResponse);
+    final ResponseList<Status> statuses = createDefaultResponseList(getLoginUser());
+    when(twitter.getUserListStatuses(anyLong(), any(Paging.class))).thenReturn(statuses);
+  }
+
+  @Override
+  protected int setupTimeline() throws TwitterException {
+    return setupDefaultTimeline();
+  }
+
+  @Override
+  protected ActivityTestRule<? extends AppCompatActivity> getRule() {
+    return rule;
+  }
+}

--- a/app/src/androidTest/java/com/freshdigitable/udonroad/TimelineInstTestBase.java
+++ b/app/src/androidTest/java/com/freshdigitable/udonroad/TimelineInstTestBase.java
@@ -160,6 +160,8 @@ public abstract class TimelineInstTestBase {
 
   protected void verifyAfterLaunch() throws Exception {
     verify(twitter, times(1)).getHomeTimeline();
+    verify(twitter, times(1)).setOAuthAccessToken(any(AccessToken.class));
+    verify(twitterStream, times(1)).setOAuthAccessToken(any(AccessToken.class));
     final UserStreamListener userStreamListener = getApp().getUserStreamListener();
     assertThat(userStreamListener, is(notNullValue()));
     onView(withId(R.id.timeline)).check(matches(isDisplayed()));
@@ -170,6 +172,7 @@ public abstract class TimelineInstTestBase {
   public void tearDown() throws Exception {
     unregisterStreamIdlingResource();
     reset(twitter);
+    reset(twitterStream);
     final AppCompatActivity activity = getRule().getActivity();
     if (activity != null) {
       activity.finish();

--- a/app/src/androidTest/java/com/freshdigitable/udonroad/TimelineInstTestBase.java
+++ b/app/src/androidTest/java/com/freshdigitable/udonroad/TimelineInstTestBase.java
@@ -104,13 +104,14 @@ public abstract class TimelineInstTestBase {
     final int initResListCount = setupTimeline();
 
     getRule().launchActivity(getIntent());
-    final IdlingResource idlingResource = getTimelineIdlingResource("launch", initResListCount);
-    try {
-      Espresso.registerIdlingResources(idlingResource);
-      verifyAfterLaunch();
-    } finally {
-      Espresso.unregisterIdlingResources(idlingResource);
-    }
+    IdlingResourceUtil.runWithIdlingResource(
+        getTimelineIdlingResource("launch", initResListCount), () -> {
+          try {
+            verifyAfterLaunch();
+          } catch (Exception e) {
+            throw new RuntimeException(e);
+          }
+        });
   }
 
   @NonNull

--- a/app/src/androidTest/java/com/freshdigitable/udonroad/datastore/AppSettingStoreTest.java
+++ b/app/src/androidTest/java/com/freshdigitable/udonroad/datastore/AppSettingStoreTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2017. Matsuda, Akihit (akihito104)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.freshdigitable.udonroad.datastore;
+
+import android.support.test.runner.AndroidJUnit4;
+
+import com.freshdigitable.udonroad.util.TestInjectionUtil;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+
+import javax.inject.Inject;
+
+import twitter4j.auth.AccessToken;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
+
+/**
+ * Created by akihit on 2017/09/09.
+ */
+@RunWith(AndroidJUnit4.class)
+public class AppSettingStoreTest {
+  @Inject
+  AppSettingStore sut;
+
+  @Before
+  public void setup() {
+    TestInjectionUtil.getComponent().inject(this);
+    sut.open();
+    sut.clear();
+    sut.close();
+  }
+
+  @Test
+  public void getCurrentAccessToken() {
+    sut.open();
+
+    final AccessToken at = Mockito.mock(AccessToken.class);
+    when(at.getUserId()).thenReturn(1000L);
+    when(at.getToken()).thenReturn("valid.token");
+    when(at.getTokenSecret()).thenReturn("valid.token.secret");
+    sut.storeAccessToken(at);
+    sut.setCurrentUserId(1000L);
+
+    final AccessToken currentUserAccessToken = sut.getCurrentUserAccessToken();
+    assertThat(at.getToken(), is(currentUserAccessToken.getToken()));
+    assertThat(at.getTokenSecret(), is(currentUserAccessToken.getTokenSecret()));
+
+    sut.close();
+  }
+
+  @Test
+  public void getCurrentAccessTokenAfterChangedCurrentUser() {
+    sut.open();
+
+    final AccessToken at = Mockito.mock(AccessToken.class);
+    when(at.getUserId()).thenReturn(1000L);
+    when(at.getToken()).thenReturn("valid.token");
+    when(at.getTokenSecret()).thenReturn("valid.token.secret");
+    sut.storeAccessToken(at);
+    sut.setCurrentUserId(1000L);
+    final AccessToken at2 = Mockito.mock(AccessToken.class);
+    when(at2.getUserId()).thenReturn(2000L);
+    when(at2.getToken()).thenReturn("valid.token.2");
+    when(at2.getTokenSecret()).thenReturn("valid.token.secret.2");
+    sut.storeAccessToken(at2);
+    sut.setCurrentUserId(2000L);
+
+    final AccessToken currentUserAccessToken2 = sut.getCurrentUserAccessToken();
+    assertThat(at2.getToken(), is(currentUserAccessToken2.getToken()));
+    assertThat(at2.getTokenSecret(), is(currentUserAccessToken2.getTokenSecret()));
+
+    sut.setCurrentUserId(1000L);
+    final AccessToken currentUserAccessToken = sut.getCurrentUserAccessToken();
+    assertThat(at.getToken(), is(currentUserAccessToken.getToken()));
+    assertThat(at.getTokenSecret(), is(currentUserAccessToken.getTokenSecret()));
+
+    sut.close();
+  }
+}

--- a/app/src/androidTest/java/com/freshdigitable/udonroad/util/AssertionUtil.java
+++ b/app/src/androidTest/java/com/freshdigitable/udonroad/util/AssertionUtil.java
@@ -101,6 +101,11 @@ public class AssertionUtil {
     onView(withId(R.id.main_toolbar)).check(matches(getToolbarMatcher(titleMatcher)));
   }
 
+  public static void checkMainActivityTitle(String title) {
+    final Matcher<View> titleMatcher = withText(title);
+    onView(withId(R.id.main_toolbar)).check(matches(getToolbarMatcher(titleMatcher)));
+  }
+
   @NonNull
   private static Matcher<View> getToolbarMatcher(Matcher<View> titleMatcher) {
     return new BoundedMatcher<View, Toolbar>(Toolbar.class) {

--- a/app/src/androidTest/java/com/freshdigitable/udonroad/util/IdlingResourceUtil.java
+++ b/app/src/androidTest/java/com/freshdigitable/udonroad/util/IdlingResourceUtil.java
@@ -22,7 +22,11 @@ import android.support.test.espresso.Espresso;
 import android.support.test.espresso.IdlingResource;
 import android.support.test.runner.lifecycle.ActivityLifecycleMonitorRegistry;
 import android.support.test.runner.lifecycle.Stage;
+import android.support.v4.widget.DrawerLayout;
 import android.util.Log;
+import android.view.View;
+
+import com.freshdigitable.udonroad.R;
 
 import java.util.Collection;
 import java.util.concurrent.Callable;
@@ -47,6 +51,24 @@ public class IdlingResourceUtil {
       }
     }
     return null;
+  }
+
+  @NonNull
+  public static IdlingResource getOpenDrawerIdlingResource(Activity activity) {
+    return IdlingResourceUtil.getSimpleIdlingResource("open drawer", () -> {
+      final DrawerLayout drawerLayout = activity.findViewById(R.id.nav_drawer_layout);
+      final View drawer = activity.findViewById(R.id.nav_drawer);
+      return drawerLayout.isDrawerOpen(drawer);
+    });
+  }
+
+  @NonNull
+  public static IdlingResource getCloseDrawerIdlingResource(Activity activity) {
+    return IdlingResourceUtil.getSimpleIdlingResource("close drawer", () -> {
+      final DrawerLayout drawerLayout = activity.findViewById(R.id.nav_drawer_layout);
+      final View drawer = activity.findViewById(R.id.nav_drawer);
+      return !drawerLayout.isDrawerOpen(drawer);
+    });
   }
 
   public static IdlingResource getSimpleIdlingResource(String name, Callable<Boolean> isIdle) {

--- a/app/src/androidTest/java/com/freshdigitable/udonroad/util/PerformUtil.java
+++ b/app/src/androidTest/java/com/freshdigitable/udonroad/util/PerformUtil.java
@@ -21,7 +21,6 @@ import android.content.Intent;
 import android.support.test.InstrumentationRegistry;
 import android.support.test.espresso.ViewAction;
 import android.support.test.espresso.ViewInteraction;
-import android.support.test.espresso.action.CoordinatesProvider;
 import android.support.test.espresso.action.GeneralClickAction;
 import android.support.test.espresso.action.GeneralLocation;
 import android.support.test.espresso.action.GeneralSwipeAction;
@@ -34,6 +33,7 @@ import android.view.View;
 import com.freshdigitable.udonroad.R;
 import com.freshdigitable.udonroad.listitem.QuotedStatusView;
 import com.freshdigitable.udonroad.listitem.StatusView;
+import com.freshdigitable.udonroad.listitem.UserItemView;
 
 import org.hamcrest.Matcher;
 
@@ -49,6 +49,7 @@ import static android.support.test.espresso.action.ViewActions.swipeUp;
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
 import static android.support.test.espresso.matcher.ViewMatchers.withText;
 import static com.freshdigitable.udonroad.util.StatusViewMatcher.asUserIcon;
+import static com.freshdigitable.udonroad.util.StatusViewMatcher.ofItemViewAt;
 import static com.freshdigitable.udonroad.util.StatusViewMatcher.ofQuotedStatusView;
 import static com.freshdigitable.udonroad.util.StatusViewMatcher.ofStatusView;
 import static com.freshdigitable.udonroad.util.StatusViewMatcher.ofStatusViewAt;
@@ -71,6 +72,10 @@ public class PerformUtil {
 
   public static ViewInteraction selectItemViewAt(int index) {
     return onView(ofStatusViewAt(R.id.timeline, index)).perform(clickForStatusView());
+  }
+
+  public static <T extends View> ViewInteraction selectItemViewAt(int index, Class<T> clz) {
+    return onView(ofItemViewAt(R.id.timeline, index, clz)).perform(clickForStatusView());
   }
 
   public static ViewInteraction reply() {
@@ -134,28 +139,25 @@ public class PerformUtil {
   }
 
   private static ViewAction clickForStatusView() {
-    return actionWithAssertions(new GeneralClickAction(Tap.SINGLE, new CoordinatesProvider() {
-      @Override
-      public float[] calculateCoordinates(View view) {
-        if (view instanceof StatusView) {
-          final View v = view.findViewById(R.id.tl_tweet);
-          return calcCenterCoord(v);
-        } else if (view instanceof QuotedStatusView) {
-          final View v = view.findViewById(R.id.q_tweet);
-          return calcCenterCoord(v);
-        }
-        return calcCenterCoord(view);
+    return actionWithAssertions(new GeneralClickAction(Tap.SINGLE, view -> {
+      if (view instanceof StatusView || view instanceof UserItemView) {
+        final View v = view.findViewById(R.id.tl_tweet);
+        return calcCenterCoord(v);
+      } else if (view instanceof QuotedStatusView) {
+        final View v = view.findViewById(R.id.q_tweet);
+        return calcCenterCoord(v);
       }
-
-      private float[] calcCenterCoord(View v) {
-        int[] pos = new int[2];
-        v.getLocationOnScreen(pos);
-        return new float[]{
-            pos[0] + v.getWidth() / 2.0f,
-            pos[1] + v.getHeight() / 2.0f,
-        };
-      }
+      return calcCenterCoord(view);
     }, Press.FINGER));
+  }
+
+  private static float[] calcCenterCoord(View v) {
+    int[] pos = new int[2];
+    v.getLocationOnScreen(pos);
+    return new float[]{
+        pos[0] + v.getWidth() / 2.0f,
+        pos[1] + v.getHeight() / 2.0f,
+    };
   }
 
   public static void launchHomeAndBackToApp(Activity base) throws InterruptedException {

--- a/app/src/androidTest/java/com/freshdigitable/udonroad/util/PerformUtil.java
+++ b/app/src/androidTest/java/com/freshdigitable/udonroad/util/PerformUtil.java
@@ -129,6 +129,10 @@ public class PerformUtil {
     onView(withId(R.id.nav_drawer_layout)).perform(DrawerActions.open());
   }
 
+  public static void closeDrawerNavigation() {
+    onView(withId(R.id.nav_drawer_layout)).perform(DrawerActions.close());
+  }
+
   private static ViewAction clickForStatusView() {
     return actionWithAssertions(new GeneralClickAction(Tap.SINGLE, new CoordinatesProvider() {
       @Override

--- a/app/src/androidTest/java/com/freshdigitable/udonroad/util/StatusViewMatcher.java
+++ b/app/src/androidTest/java/com/freshdigitable/udonroad/util/StatusViewMatcher.java
@@ -67,15 +67,12 @@ public class StatusViewMatcher {
     };
   }
 
-  public static Matcher<View> ofStatusViewAt(@IdRes final int recyclerViewId, final int position) {
+  public static <T extends View> Matcher<View> ofItemViewAt(
+      @IdRes final int recyclerViewId, final int position, Class<T> clz) {
     final Matcher<View> recyclerViewMatcher = withId(recyclerViewId);
-    return new BoundedMatcher<View, StatusView>(StatusView.class) {
+    return new BoundedMatcher<View, T>(clz) {
       @Override
-      public void describeTo(Description description) {
-      }
-
-      @Override
-      protected boolean matchesSafely(StatusView item) {
+      protected boolean matchesSafely(T item) {
         final RecyclerView recyclerView = (RecyclerView) item.getParent();
         if (!recyclerViewMatcher.matches(recyclerView)) {
           return false;
@@ -83,7 +80,14 @@ public class StatusViewMatcher {
         final View target = recyclerView.getChildAt(position);
         return target == item;
       }
+
+      @Override
+      public void describeTo(Description description) {}
     };
+  }
+
+  public static Matcher<View> ofStatusViewAt(@IdRes final int recyclerViewId, final int position) {
+    return ofItemViewAt(recyclerViewId, position, StatusView.class);
   }
 
   public static Matcher<View> asUserIcon(@IdRes final int resId, final Matcher<View> root) {

--- a/app/src/androidTest/java/com/freshdigitable/udonroad/util/StorageUtil.java
+++ b/app/src/androidTest/java/com/freshdigitable/udonroad/util/StorageUtil.java
@@ -49,7 +49,11 @@ public class StorageUtil {
 
   private static File[] listDir() {
     final File realmDirectory = new RealmConfiguration.Builder().build().getRealmDirectory();
-    return realmDirectory.listFiles(f -> f.isDirectory() && f.getName().startsWith("user_"));
+    final File[] dirs = realmDirectory.listFiles(f -> f.isDirectory() && f.getName().startsWith("user_"));
+    final File[] res = new File[dirs.length + 1];
+    System.arraycopy(dirs, 0, res, 0, dirs.length);
+    res[dirs.length] = realmDirectory;
+    return res;
   }
 
   public static void checkAllRealmInstanceCleared() {  // XXX

--- a/app/src/androidTest/java/com/freshdigitable/udonroad/util/TwitterResponseMock.java
+++ b/app/src/androidTest/java/com/freshdigitable/udonroad/util/TwitterResponseMock.java
@@ -30,13 +30,16 @@ import io.reactivex.Observable;
 import io.reactivex.schedulers.Schedulers;
 import twitter4j.HashtagEntity;
 import twitter4j.MediaEntity;
+import twitter4j.PagableResponseList;
 import twitter4j.RateLimitStatus;
 import twitter4j.ResponseList;
 import twitter4j.Status;
 import twitter4j.StatusDeletionNotice;
 import twitter4j.TwitterAPIConfiguration;
+import twitter4j.TwitterResponse;
 import twitter4j.URLEntity;
 import twitter4j.User;
+import twitter4j.UserList;
 import twitter4j.UserMentionEntity;
 import twitter4j.UserStreamListener;
 
@@ -274,5 +277,177 @@ public class TwitterResponseMock {
     when(mock.getShortURLLength()).thenReturn(23);
     when(mock.getShortURLLengthHttps()).thenReturn(23);
     return mock;
+  }
+
+  public static PagableResponseList<UserList> createUserListResponse(int size) {
+    final User userA = UserUtil.createUserA();
+    final ArrayList<UserList> res = new ArrayList<>(size);
+    for (int i = 0; i < size; i++) {
+      final UserList userList = mock(UserList.class);
+      when(userList.getId()).thenReturn((long) (Integer.MAX_VALUE + i));
+      final String name = "list" + i;
+      when(userList.getName()).thenReturn(name);
+      when(userList.getDescription()).thenReturn("list description");
+      when(userList.getFullName()).thenReturn("@user/" + name);
+      when(userList.getUser()).thenReturn(userA);
+      when(userList.isPublic()).thenReturn(true);
+      res.add(userList);
+    }
+    return createPagableResponseList(res);
+  }
+
+  private static <T extends TwitterResponse> PagableResponseList<T> createPagableResponseList(List<T> list) {
+    return new PagableResponseList<T>() {
+      @Override
+      public boolean hasPrevious() {
+        return false;
+      }
+
+      @Override
+      public long getPreviousCursor() {
+        return 0;
+      }
+
+      @Override
+      public boolean hasNext() {
+        return false;
+      }
+
+      @Override
+      public long getNextCursor() {
+        return 0;
+      }
+
+      @Override
+      public RateLimitStatus getRateLimitStatus() {
+        return null;
+      }
+
+      @Override
+      public int size() {
+        return list.size();
+      }
+
+      @Override
+      public boolean isEmpty() {
+        return list.isEmpty();
+      }
+
+      @Override
+      public boolean contains(Object o) {
+        return list.contains(o);
+      }
+
+      @NonNull
+      @Override
+      public Iterator<T> iterator() {
+        return list.iterator();
+      }
+
+      @NonNull
+      @Override
+      public Object[] toArray() {
+        return list.toArray();
+      }
+
+      @NonNull
+      @Override
+      public <T1> T1[] toArray(@NonNull T1[] t1s) {
+        return list.toArray(t1s);
+      }
+
+      @Override
+      public boolean containsAll(@NonNull Collection<?> collection) {
+        return list.containsAll(collection);
+      }
+
+      @Override
+      public T get(int i) {
+        return list.get(i);
+      }
+
+      @Override
+      public int indexOf(Object o) {
+        return list.indexOf(o);
+      }
+
+      @Override
+      public int lastIndexOf(Object o) {
+        return list.lastIndexOf(o);
+      }
+
+      @NonNull
+      @Override
+      public ListIterator<T> listIterator() {
+        return list.listIterator();
+      }
+
+      @NonNull
+      @Override
+      public ListIterator<T> listIterator(int i) {
+        return list.listIterator(i);
+      }
+
+      @NonNull
+      @Override
+      public List<T> subList(int i, int i1) {
+        return list.subList(i, i1);
+      }
+
+      @Override
+      public int getAccessLevel() {
+        return 0;
+      }
+
+      @Override
+      public boolean add(T t) {
+        throw new AssertionError("not supported.");
+      }
+
+      @Override
+      public boolean remove(Object o) {
+        throw new AssertionError("not supported.");
+      }
+
+      @Override
+      public boolean addAll(@NonNull Collection<? extends T> collection) {
+        throw new AssertionError("not supported.");
+      }
+
+      @Override
+      public boolean addAll(int i, @NonNull Collection<? extends T> collection) {
+        throw new AssertionError("not supported.");
+      }
+
+      @Override
+      public boolean removeAll(@NonNull Collection<?> collection) {
+        throw new AssertionError("not supported.");
+      }
+
+      @Override
+      public boolean retainAll(@NonNull Collection<?> collection) {
+        throw new AssertionError("not supported.");
+      }
+
+      @Override
+      public void clear() {
+        throw new AssertionError("not supported.");
+      }
+
+      @Override
+      public T set(int i, T t) {
+        throw new AssertionError("not supported.");
+      }
+
+      @Override
+      public void add(int i, T t) {
+        throw new AssertionError("not supported.");
+      }
+
+      @Override
+      public T remove(int i) {
+        throw new AssertionError("not supported.");
+      }
+    };
   }
 }

--- a/app/src/androidTest/java/com/freshdigitable/udonroad/util/UserUtil.java
+++ b/app/src/androidTest/java/com/freshdigitable/udonroad/util/UserUtil.java
@@ -31,6 +31,11 @@ public class UserUtil {
         .name("User A").build();
   }
 
+  public static User createUserAsub() {
+    return builder(Integer.MAX_VALUE + 2000L, "userAsub")
+        .name("User A (sub)").build();
+  }
+
   public static User createVerifiedUser() {
     return builder(3000,"verifiedUser")
         .name("Verified User")

--- a/app/src/main/java/com/freshdigitable/udonroad/DrawerNavigator.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/DrawerNavigator.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2017. Matsuda, Akihit (akihito104)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.freshdigitable.udonroad;
+
+import android.content.Context;
+import android.graphics.drawable.Drawable;
+import android.support.annotation.IdRes;
+import android.support.annotation.NonNull;
+import android.support.design.widget.NavigationView;
+import android.support.v4.widget.DrawerLayout;
+import android.support.v4.widget.TextViewCompat;
+import android.support.v7.content.res.AppCompatResources;
+import android.util.Log;
+import android.view.Menu;
+import android.view.MenuItem;
+
+import com.freshdigitable.udonroad.databinding.NavHeaderBinding;
+import com.freshdigitable.udonroad.datastore.AppSettingStore;
+import com.freshdigitable.udonroad.listitem.TwitterCombinedName;
+import com.squareup.picasso.Picasso;
+
+import java.util.List;
+
+import io.reactivex.disposables.Disposable;
+import twitter4j.User;
+
+/**
+ * Created by akihit on 2017/09/15.
+ */
+
+class DrawerNavigator {
+  private static String TAG = DrawerNavigator.class.getSimpleName();
+  private final DrawerLayout drawerLayout;
+  private final NavigationView navigationView;
+  private final NavHeaderBinding navHeaderBinding;
+  private final Drawable upArrow, downArrow;
+  private final AppSettingStore appSettings;
+
+  DrawerNavigator(@NonNull DrawerLayout drawerLayout, @NonNull NavigationView navigationView,
+                  @NonNull NavHeaderBinding navHeaderBinding, @NonNull AppSettingStore appSetting) {
+    this.drawerLayout = drawerLayout;
+    this.navigationView = navigationView;
+    this.navHeaderBinding = navHeaderBinding;
+    this.appSettings = appSetting;
+
+    final Context context = drawerLayout.getContext();
+    downArrow = AppCompatResources.getDrawable(context, R.drawable.ic_arrow_drop_down);
+    upArrow = AppCompatResources.getDrawable(context, R.drawable.ic_arrow_drop_up);
+
+    TextViewCompat.setCompoundDrawablesRelativeWithIntrinsicBounds(this.navHeaderBinding.navHeaderAccount,
+        null, null, downArrow, null);
+    this.navigationView.addHeaderView(this.navHeaderBinding.getRoot());
+  }
+
+  boolean isMenuDefault() {
+    return navigationView.getMenu().findItem(R.id.drawer_menu_home).isVisible();
+  }
+
+  void setMenuByGroupId(@IdRes int groupId) {
+    TextViewCompat.setCompoundDrawablesRelativeWithIntrinsicBounds(navHeaderBinding.navHeaderAccount,
+        null, null, groupId == R.id.drawer_menu_default ? downArrow : upArrow, null);
+    final Menu menu = navigationView.getMenu();
+    for (int i = 0; i < menu.size(); i++) {
+      final MenuItem item = menu.getItem(i);
+      item.setVisible(item.getGroupId() == groupId);
+    }
+  }
+
+  private Disposable subscription;
+
+  void changeCurrentUser() {
+    unsubscribeCurrentUser();
+    subscription = appSettings.observeCurrentUser()
+        .subscribe(this::setupHeader,
+            e -> Log.e(TAG, "setupNavigationDrawer: ", e));
+    setAccountList();
+  }
+
+  void unsubscribeCurrentUser() {
+    if (subscription != null && !subscription.isDisposed()) {
+      subscription.dispose();
+    }
+  }
+
+  private void setupHeader(User currentUser) {
+    Picasso.with(navigationView.getContext())
+        .load(currentUser.getProfileImageURLHttps())
+        .resizeDimen(R.dimen.nav_drawer_header_icon, R.dimen.nav_drawer_header_icon)
+        .into(navHeaderBinding.navHeaderIcon);
+
+    navHeaderBinding.navHeaderIcon.setOnClickListener(v -> {
+      final long userId = currentUser.getId();
+      UserInfoActivity.start(v.getContext(), userId);
+    });
+
+    navHeaderBinding.navHeaderAccount.setNames(new TwitterCombinedName(currentUser));
+
+    final String userScreenName = "@" + currentUser.getScreenName();
+    navHeaderBinding.navHeaderAccount.setOnClickListener(v -> {
+      if (isMenuDefault()) {
+        setMenuByGroupId(R.id.drawer_menu_accounts);
+        final Menu menu = navigationView.getMenu();
+        for (int i = 0; i < menu.size(); i++) {
+          final MenuItem item = menu.getItem(i);
+          if (item.getGroupId() == R.id.drawer_menu_accounts
+              && userScreenName.equals(item.getTitle().toString())) {
+            item.setVisible(false);
+          }
+        }
+      } else {
+        setMenuByGroupId(R.id.drawer_menu_default);
+      }
+    });
+  }
+
+  private void setAccountList() {
+    final long currentUserId = appSettings.getCurrentUserId();
+    final List<? extends User> users = appSettings.getAllAuthenticatedUsers();
+    final Menu menu = navigationView.getMenu();
+    for (int i = 0; i < users.size(); i++) {
+      final User user = users.get(i);
+      if (user.getId() == currentUserId || isAccountRegistered(menu, user.getScreenName())) {
+        continue;
+      }
+      final int id = i != R.id.drawer_menu_add_account ? i
+          : ((int) ((R.id.drawer_menu_add_account + 1L + i) % Integer.MAX_VALUE));
+      final MenuItem item = menu.add(R.id.drawer_menu_accounts, id, i, "@" + user.getScreenName());
+      item.setVisible(false);
+    }
+  }
+
+  private static boolean isAccountRegistered(Menu menu, String screenName) {
+    for (int i = 0; i < menu.size(); i++) {
+      final MenuItem item = menu.getItem(i);
+      if (item.getGroupId() == R.id.drawer_menu_accounts
+          && item.getTitle().toString().endsWith(screenName)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  boolean isDrawerOpen() {
+    return drawerLayout.isDrawerOpen(navigationView);
+  }
+
+  void closeDrawer() {
+    drawerLayout.closeDrawer(navigationView);
+  }
+
+  void release() {
+    final RoundedCornerImageView navHeaderIcon = navHeaderBinding.navHeaderIcon;
+    Picasso.with(navHeaderIcon.getContext()).cancelRequest(navHeaderIcon);
+    navHeaderIcon.setOnClickListener(null);
+    navHeaderBinding.navHeaderAccount.setOnClickListener(null);
+    navigationView.setNavigationItemSelectedListener(null);
+  }
+}

--- a/app/src/main/java/com/freshdigitable/udonroad/MainActivity.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/MainActivity.java
@@ -130,16 +130,23 @@ public class MainActivity extends AppCompatActivity
     appSettingRequestWorker.verifyCredentials();
     binding.navDrawer.setNavigationItemSelectedListener(item -> {
       int itemId = item.getItemId();
-      if (itemId == R.id.drawer_menu_home) {
-        Log.d(TAG, "home is selected");
-        timelineContainerSwitcher.showMain();
-        binding.navDrawerLayout.closeDrawer(binding.navDrawer);
-      } else if (itemId == R.id.drawer_menu_lists) {
-        timelineContainerSwitcher.showOwnedLists(appSetting.getCurrentUserId());
-        binding.navDrawerLayout.closeDrawer(binding.navDrawer);
-      } else if (itemId == R.id.drawer_menu_license) {
-        startActivity(new Intent(getApplicationContext(), LicenseActivity.class));
-        binding.navDrawerLayout.closeDrawer(binding.navDrawer);
+      if (item.getGroupId() == R.id.drawer_menu_default) {
+        if (itemId == R.id.drawer_menu_home) {
+          Log.d(TAG, "home is selected");
+          timelineContainerSwitcher.showMain();
+          binding.navDrawerLayout.closeDrawer(binding.navDrawer);
+        } else if (itemId == R.id.drawer_menu_lists) {
+          timelineContainerSwitcher.showOwnedLists(appSetting.getCurrentUserId());
+          binding.navDrawerLayout.closeDrawer(binding.navDrawer);
+        } else if (itemId == R.id.drawer_menu_license) {
+          startActivity(new Intent(getApplicationContext(), LicenseActivity.class));
+          binding.navDrawerLayout.closeDrawer(binding.navDrawer);
+        }
+      } else if (item.getGroupId() == R.id.drawer_menu_accounts) {
+        if (item.getItemId() == R.id.drawer_menu_add_account) {
+          OAuthActivity.start(this);
+          finish();
+        }
       }
       return false;
     });
@@ -159,7 +166,7 @@ public class MainActivity extends AppCompatActivity
         super.onDrawerClosed(drawerView);
         tlFragment.startScroll();
         if (!isNavDrawerMenuDefault()) {
-          setNavDrawerMenuDefault();
+          setNavDrawerMenuByGroupId(R.id.drawer_menu_default);
         }
       }
     };
@@ -172,12 +179,12 @@ public class MainActivity extends AppCompatActivity
     return binding.navDrawer.getMenu().findItem(R.id.drawer_menu_home).isVisible();
   }
 
-  private void setNavDrawerMenuDefault() {
+  private void setNavDrawerMenuByGroupId(@IdRes int groupId) {
     final Menu menu = binding.navDrawer.getMenu();
-    menu.findItem(R.id.drawer_menu_home).setVisible(true);
-    menu.findItem(R.id.drawer_menu_lists).setVisible(true);
-    menu.findItem(R.id.drawer_menu_license).setVisible(true);
-    menu.findItem(R.id.drawer_menu_add_account).setVisible(false);
+    for (int i = 0; i < menu.size(); i++) {
+      final MenuItem item = menu.getItem(i);
+      item.setVisible(item.getGroupId() == groupId);
+    }
   }
 
   private void setupNavigationDrawerHeader(User user) {
@@ -188,11 +195,7 @@ public class MainActivity extends AppCompatActivity
         .into(navHeaderBinding.navHeaderIcon);
     navHeaderBinding.navHeaderIcon.setOnClickListener(v -> UserInfoActivity.start(this, user, v));
     navHeaderBinding.navHeaderAccount.setOnClickListener(v -> {
-      final Menu menu = binding.navDrawer.getMenu();
-      menu.findItem(R.id.drawer_menu_home).setVisible(false);
-      menu.findItem(R.id.drawer_menu_lists).setVisible(false);
-      menu.findItem(R.id.drawer_menu_license).setVisible(false);
-      menu.findItem(R.id.drawer_menu_add_account).setVisible(true);
+      setNavDrawerMenuByGroupId(R.id.drawer_menu_accounts);
     });
   }
 
@@ -248,7 +251,7 @@ public class MainActivity extends AppCompatActivity
   public void onBackPressed() {
     if (binding.navDrawerLayout.isDrawerOpen(binding.navDrawer)) {
       if (!isNavDrawerMenuDefault()) {
-        setNavDrawerMenuDefault();
+        setNavDrawerMenuByGroupId(R.id.drawer_menu_default);
         return;
       }
       binding.navDrawerLayout.closeDrawer(binding.navDrawer);

--- a/app/src/main/java/com/freshdigitable/udonroad/MainActivity.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/MainActivity.java
@@ -29,6 +29,7 @@ import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
 import android.util.Log;
 import android.view.LayoutInflater;
+import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.Window;
@@ -136,11 +137,9 @@ public class MainActivity extends AppCompatActivity
       } else if (itemId == R.id.drawer_menu_lists) {
         timelineContainerSwitcher.showOwnedLists(appSetting.getCurrentUserId());
         binding.navDrawerLayout.closeDrawer(binding.navDrawer);
-      } else {
-        if (itemId == R.id.drawer_menu_license) {
-          startActivity(new Intent(getApplicationContext(), LicenseActivity.class));
-          binding.navDrawerLayout.closeDrawer(binding.navDrawer);
-        }
+      } else if (itemId == R.id.drawer_menu_license) {
+        startActivity(new Intent(getApplicationContext(), LicenseActivity.class));
+        binding.navDrawerLayout.closeDrawer(binding.navDrawer);
       }
       return false;
     });
@@ -159,11 +158,26 @@ public class MainActivity extends AppCompatActivity
       public void onDrawerClosed(View drawerView) {
         super.onDrawerClosed(drawerView);
         tlFragment.startScroll();
+        if (!isNavDrawerMenuDefault()) {
+          setNavDrawerMenuDefault();
+        }
       }
     };
     actionBarDrawerToggle.setDrawerIndicatorEnabled(true);
     binding.navDrawerLayout.addDrawerListener(actionBarDrawerToggle);
     actionBarDrawerToggle.syncState();
+  }
+
+  private boolean isNavDrawerMenuDefault() {
+    return binding.navDrawer.getMenu().findItem(R.id.drawer_menu_home).isVisible();
+  }
+
+  private void setNavDrawerMenuDefault() {
+    final Menu menu = binding.navDrawer.getMenu();
+    menu.findItem(R.id.drawer_menu_home).setVisible(true);
+    menu.findItem(R.id.drawer_menu_lists).setVisible(true);
+    menu.findItem(R.id.drawer_menu_license).setVisible(true);
+    menu.findItem(R.id.drawer_menu_add_account).setVisible(false);
   }
 
   private void setupNavigationDrawerHeader(User user) {
@@ -173,6 +187,13 @@ public class MainActivity extends AppCompatActivity
         .resizeDimen(R.dimen.nav_drawer_header_icon, R.dimen.nav_drawer_header_icon)
         .into(navHeaderBinding.navHeaderIcon);
     navHeaderBinding.navHeaderIcon.setOnClickListener(v -> UserInfoActivity.start(this, user, v));
+    navHeaderBinding.navHeaderAccount.setOnClickListener(v -> {
+      final Menu menu = binding.navDrawer.getMenu();
+      menu.findItem(R.id.drawer_menu_home).setVisible(false);
+      menu.findItem(R.id.drawer_menu_lists).setVisible(false);
+      menu.findItem(R.id.drawer_menu_license).setVisible(false);
+      menu.findItem(R.id.drawer_menu_add_account).setVisible(true);
+    });
   }
 
   @Override
@@ -226,6 +247,10 @@ public class MainActivity extends AppCompatActivity
   @Override
   public void onBackPressed() {
     if (binding.navDrawerLayout.isDrawerOpen(binding.navDrawer)) {
+      if (!isNavDrawerMenuDefault()) {
+        setNavDrawerMenuDefault();
+        return;
+      }
       binding.navDrawerLayout.closeDrawer(binding.navDrawer);
       return;
     }

--- a/app/src/main/java/com/freshdigitable/udonroad/MainActivity.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/MainActivity.java
@@ -169,6 +169,7 @@ public class MainActivity extends AppCompatActivity
                 }
                 binding.mainToolbar.setTitle(title);
               });
+              ((MainApplication) getApplication()).connectStream();
               binding.navDrawerLayout.closeDrawer(binding.navDrawer);
             }
           }

--- a/app/src/main/java/com/freshdigitable/udonroad/MainApplication.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/MainApplication.java
@@ -108,7 +108,12 @@ public class MainApplication extends Application {
 
   private boolean loggedIn = false;
 
+  void login(long userId) {
+    login(this, userId);
+  }
+
   private static void login(MainApplication app, long userId) {
+    Log.d("MainApplication", "login: " + userId);
     app.appSettings.setCurrentUserId(userId);
     final AccessToken accessToken = app.appSettings.getCurrentUserAccessToken();
     if (accessToken == null) {
@@ -125,6 +130,7 @@ public class MainApplication extends Application {
   }
 
   private static void logout(MainApplication app) {
+    Log.d("MainApplication", "logout: ");
     app.userStreamUtil.disconnect();
     app.twitterApi.setOAuthAccessToken(null);
     app.twitterStreamApi.setOAuthAccessToken(null);
@@ -133,14 +139,13 @@ public class MainApplication extends Application {
 
   private static class ActivityLifecycleCallbacksImpl implements ActivityLifecycleCallbacks {
     private static final String TAG = ActivityLifecycleCallbacksImpl.class.getSimpleName();
-    private boolean isTokenSetup = false;
     private final List<String> activities = new ArrayList<>();
 
     @Override
     public void onActivityCreated(Activity activity, Bundle savedInstanceState) {
       Log.d(TAG, "onActivityCreated: count>" + activities.size());
-      if (activities.size() == 0 || !isTokenSetup) {
-        isTokenSetup = setupAccessToken(activity);
+      if (activities.size() == 0 || !getApplication(activity).loggedIn) {
+        setupAccessToken(activity);
       }
       if (!getApplication(activity).loggedIn) {
         launchOAuthActivity(activity);

--- a/app/src/main/java/com/freshdigitable/udonroad/MainApplication.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/MainApplication.java
@@ -137,6 +137,10 @@ public class MainApplication extends Application {
     app.loggedIn = false;
   }
 
+  void connectStream() {
+    userStreamUtil.connect(StoreType.HOME.storeName);
+  }
+
   private static class ActivityLifecycleCallbacksImpl implements ActivityLifecycleCallbacks {
     private static final String TAG = ActivityLifecycleCallbacksImpl.class.getSimpleName();
     private final List<String> activities = new ArrayList<>();
@@ -169,7 +173,7 @@ public class MainApplication extends Application {
     @Override
     public void onActivityStarted(Activity activity) {
       if (activity instanceof MainActivity) {
-        getApplication(activity).userStreamUtil.connect(StoreType.HOME.storeName);
+        getApplication(activity).connectStream();
       }
       if (activity instanceof SnackbarCapable) {
         final View rootView = ((SnackbarCapable) activity).getRootView();

--- a/app/src/main/java/com/freshdigitable/udonroad/MainApplication.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/MainApplication.java
@@ -123,6 +123,7 @@ public class MainApplication extends Application {
     app.twitterApi.setOAuthAccessToken(accessToken);
     app.twitterStreamApi.setOAuthAccessToken(accessToken);
     app.loggedIn = true;
+    app.appSettingWorker.verifyCredentials();
   }
 
   void logout() {

--- a/app/src/main/java/com/freshdigitable/udonroad/OAuthActivity.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/OAuthActivity.java
@@ -88,6 +88,7 @@ public class OAuthActivity extends AppCompatActivity
   @Inject
   PublishProcessor<UserFeedbackEvent> userFeedback;
   private IndicatableFFAB ffab;
+  private Toolbar toolbar;
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
@@ -97,7 +98,7 @@ public class OAuthActivity extends AppCompatActivity
 
     ffab = findViewById(R.id.ffab);
 
-    final Toolbar toolbar = findViewById(R.id.oauth_toolbar);
+    toolbar = findViewById(R.id.oauth_toolbar);
     setSupportActionBar(toolbar);
 
     final DemoTimelineFragment demoTimelineFragment = new DemoTimelineFragment();
@@ -148,6 +149,12 @@ public class OAuthActivity extends AppCompatActivity
         listener.onItemSelected(item);
       }
     });
+    appSettings.open();
+    final List<? extends User> users = appSettings.getAllAuthenticatedUsers();
+    if (users.size() > 0) {
+      toolbar.setTitle(R.string.title_add_account);
+    }
+    appSettings.close();
   }
 
   @Override
@@ -162,6 +169,17 @@ public class OAuthActivity extends AppCompatActivity
     if (updateSubject != null && !updateSubject.hasCompleted()) {
       updateSubject.onComplete();
     }
+  }
+
+  @Override
+  public void onBackPressed() {
+    appSettings.open();
+    final List<? extends User> users = appSettings.getAllAuthenticatedUsers();
+    if (users.size() > 0) {
+      startActivity(new Intent(this, getRedirect()));
+    }
+    appSettings.close();
+    super.onBackPressed();
   }
 
   private RequestToken requestToken;
@@ -192,6 +210,7 @@ public class OAuthActivity extends AppCompatActivity
     appSettings.open();
     appSettings.storeAccessToken(accessToken);
     appSettings.setCurrentUserId(accessToken.getUserId());
+    ((MainApplication) getApplication()).logout();
     appSettings.close();
     userFeedback.onNext(new UserFeedbackEvent(R.string.msg_oauth_success));
     Intent intent = new Intent(this, getRedirect());

--- a/app/src/main/java/com/freshdigitable/udonroad/OAuthActivity.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/OAuthActivity.java
@@ -151,7 +151,7 @@ public class OAuthActivity extends AppCompatActivity
     });
     appSettings.open();
     final List<? extends User> users = appSettings.getAllAuthenticatedUsers();
-    if (users.size() > 0) {
+    if (!users.isEmpty()) {
       toolbar.setTitle(R.string.title_add_account);
     }
     appSettings.close();
@@ -175,7 +175,7 @@ public class OAuthActivity extends AppCompatActivity
   public void onBackPressed() {
     appSettings.open();
     final List<? extends User> users = appSettings.getAllAuthenticatedUsers();
-    if (users.size() > 0) {
+    if (!users.isEmpty()) {
       startActivity(new Intent(this, getRedirect()));
     }
     appSettings.close();
@@ -185,6 +185,7 @@ public class OAuthActivity extends AppCompatActivity
   private RequestToken requestToken;
 
   private void startAuthorization() {
+    ((MainApplication) getApplication()).logout();
     twitterApi.fetchOAuthRequestToken()
         .observeOn(AndroidSchedulers.mainThread())
         .doOnError(err -> Log.e(TAG, "authentication error: ", err))

--- a/app/src/main/java/com/freshdigitable/udonroad/TimelineContainerSwitcher.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/TimelineContainerSwitcher.java
@@ -164,6 +164,14 @@ class TimelineContainerSwitcher {
     return false;
   }
 
+  void clear() {
+    setOnContentChangedListener(null);
+    showMain();
+    getSupportFragmentManager().beginTransaction()
+        .remove(mainFragment)
+        .commitNow();
+  }
+
   interface OnContentChangedListener {
     void onContentChanged(ContentType type, String title);
   }

--- a/app/src/main/java/com/freshdigitable/udonroad/TimelineContainerSwitcher.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/TimelineContainerSwitcher.java
@@ -75,9 +75,9 @@ class TimelineContainerSwitcher {
     replaceTimelineContainer(ContentType.SEARCH, -1, query, fragment);
   }
 
-  void showOwnedLists(long currentUserId) {
-    final TimelineFragment<?> fragment = TimelineFragment.getInstance(StoreType.OWNED_LIST, currentUserId);
-    replaceTimelineContainer(ContentType.LISTS, currentUserId, null, fragment);
+  void showOwnedLists() {
+    final TimelineFragment<?> fragment = TimelineFragment.getInstance(StoreType.OWNED_LIST, -1);
+    replaceTimelineContainer(ContentType.LISTS, -1, null, fragment);
   }
 
   void showListTimeline(long listId, String query) {
@@ -249,10 +249,10 @@ class TimelineContainerSwitcher {
         switcher.listener.onContentChanged(this, tag.substring(tagPrefix.length()));
         switcher.setDetailIsEnabled(true);
       }
-    }, LISTS(R.string.title_owned_list, StoreType.OWNED_LIST.prefix()) {
+    }, LISTS(R.string.title_owned_list, StoreType.OWNED_LIST.storeName) {
       @Override
       String createTag(long id, String query) {
-        return StoreType.OWNED_LIST.nameWithSuffix(id, query);
+        return StoreType.OWNED_LIST.storeName;
       }
 
       @Override

--- a/app/src/main/java/com/freshdigitable/udonroad/TweetInputFragment.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/TweetInputFragment.java
@@ -167,7 +167,6 @@ public class TweetInputFragment extends Fragment {
   public void onStart() {
     Log.d(TAG, "onStart: ");
     super.onStart();
-    statusCache.open();
     appSettings.open();
 
     final TweetInputView inputText = binding.mainTweetInputView;
@@ -203,7 +202,6 @@ public class TweetInputFragment extends Fragment {
       subscription.dispose();
     }
     appSettings.close();
-    statusCache.close();
     binding.mainTweetInputView.getAppendImageButton().setOnClickListener(null);
     binding.mainTweetInputView.removeTextWatcher(textWatcher);
     tweetSendFab.setOnClickListener(null);
@@ -256,12 +254,14 @@ public class TweetInputFragment extends Fragment {
   private ReplyEntity replyEntity;
 
   private void setupReplyEntity(long inReplyToStatusId) {
+    statusCache.open();
     final Status inReplyTo = statusCache.find(inReplyToStatusId);
     if (inReplyTo != null) {
       replyEntity = ReplyEntity.create(inReplyTo, appSettings.getCurrentUserId());
       binding.mainTweetInputView.addText(replyEntity.createReplyString());
       binding.mainTweetInputView.setInReplyTo();
     }
+    statusCache.close();
   }
 
   private void setupQuote(long quotedStatus) {
@@ -313,6 +313,7 @@ public class TweetInputFragment extends Fragment {
       return statusRequestWorker.observeUpdateStatus(sendingText);
     }
     StringBuilder s = new StringBuilder(sendingText);
+    statusCache.open();
     for (long q : quoteStatusIds) {
       final Status status = statusCache.find(q);
       if (status == null) {
@@ -321,6 +322,7 @@ public class TweetInputFragment extends Fragment {
       s.append(" https://twitter.com/")
           .append(status.getUser().getScreenName()).append("/status/").append(q);
     }
+    statusCache.close();
     final StatusUpdate statusUpdate = new StatusUpdate(s.toString());
     if (replyEntity != null) {
       statusUpdate.setInReplyToStatusId(replyEntity.inReplyToStatusId);

--- a/app/src/main/java/com/freshdigitable/udonroad/UserStreamUtil.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/UserStreamUtil.java
@@ -110,7 +110,6 @@ public class UserStreamUtil {
       sortedStatusCache.open(storeName);
       appSettings.open();
       userId = appSettings.getCurrentUserId();
-      streamApi.setOAuthAccessToken(appSettings.getCurrentUserAccessToken());
       streamApi.connectUserStream(statusListener);
       isConnectedUserStream = true;
     }

--- a/app/src/main/java/com/freshdigitable/udonroad/datastore/AppSettingStore.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/datastore/AppSettingStore.java
@@ -16,6 +16,8 @@
 
 package com.freshdigitable.udonroad.datastore;
 
+import java.io.File;
+
 import io.reactivex.Observable;
 import twitter4j.TwitterAPIConfiguration;
 import twitter4j.User;
@@ -39,6 +41,8 @@ public interface AppSettingStore extends BaseCache {
   AccessToken getCurrentUserAccessToken();
 
   long getCurrentUserId();
+
+  File getCurrentUserDir();
 
   void setCurrentUserId(long userId);
 

--- a/app/src/main/java/com/freshdigitable/udonroad/datastore/AppSettingStore.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/datastore/AppSettingStore.java
@@ -17,6 +17,7 @@
 package com.freshdigitable.udonroad.datastore;
 
 import java.io.File;
+import java.util.List;
 
 import io.reactivex.Observable;
 import twitter4j.TwitterAPIConfiguration;
@@ -29,6 +30,8 @@ import twitter4j.auth.AccessToken;
 
 public interface AppSettingStore extends BaseCache {
   void addAuthenticatedUser(User authenticatedUser);
+
+  List<? extends User> getAllAuthenticatedUsers();
 
   void setTwitterAPIConfig(TwitterAPIConfiguration twitterAPIConfig);
 

--- a/app/src/main/java/com/freshdigitable/udonroad/datastore/AppSettingStore.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/datastore/AppSettingStore.java
@@ -47,6 +47,8 @@ public interface AppSettingStore extends BaseCache {
 
   File getCurrentUserDir();
 
+  String getCurrentUserScreenName();
+
   void setCurrentUserId(long userId);
 
   Observable<User> observeCurrentUser();

--- a/app/src/main/java/com/freshdigitable/udonroad/datastore/AppSettingStore.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/datastore/AppSettingStore.java
@@ -47,8 +47,6 @@ public interface AppSettingStore extends BaseCache {
 
   File getCurrentUserDir();
 
-  String getCurrentUserScreenName();
-
   void setCurrentUserId(long userId);
 
   Observable<User> observeCurrentUser();

--- a/app/src/main/java/com/freshdigitable/udonroad/module/realm/AppSettingStoreRealm.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/module/realm/AppSettingStoreRealm.java
@@ -84,6 +84,9 @@ public class AppSettingStoreRealm implements AppSettingStore {
 
   @Override
   public void addAuthenticatedUser(final User authenticatedUser) {
+    if (!isAuthenticatedUser(authenticatedUser.getId())) {
+      throw new IllegalArgumentException("unregistered userId: " + authenticatedUser.getId());
+    }
     final UserRealm user = realm.where(UserRealm.class)
         .equalTo("id", authenticatedUser.getId())
         .findFirst();
@@ -189,8 +192,21 @@ public class AppSettingStoreRealm implements AppSettingStore {
 
   @Override
   public void setCurrentUserId(long userId) {
+    if (!isAuthenticatedUser(userId)) {
+      throw new IllegalArgumentException("unregistered userId: " + userId);
+    }
     prefs.edit()
         .putLong(CURRENT_USER_ID, userId)
         .apply();
+  }
+
+  private boolean isAuthenticatedUser(long userId) {
+    final Set<String> userIds = prefs.getStringSet(AUTHENTICATED_USERS, new HashSet<>());
+    for (String id : userIds) {
+      if (id.equals(Long.toString(userId))) {
+        return true;
+      }
+    }
+    return false;
   }
 }

--- a/app/src/main/java/com/freshdigitable/udonroad/module/realm/AppSettingStoreRealm.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/module/realm/AppSettingStoreRealm.java
@@ -21,6 +21,7 @@ import android.content.SharedPreferences;
 import com.freshdigitable.udonroad.StoreType;
 import com.freshdigitable.udonroad.datastore.AppSettingStore;
 
+import java.io.File;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
@@ -43,13 +44,15 @@ public class AppSettingStoreRealm implements AppSettingStore {
   private Realm realm;
   private final RealmConfiguration config;
   private final SharedPreferences prefs;
+  private final File filesDir;
 
-  public AppSettingStoreRealm(SharedPreferences prefs) {
+  public AppSettingStoreRealm(SharedPreferences prefs, File filesDir) {
     config = new RealmConfiguration.Builder()
         .name(StoreType.APP_SETTINGS.storeName)
         .deleteRealmIfMigrationNeeded()
         .build();
     this.prefs = prefs;
+    this.filesDir = filesDir;
   }
 
   @Override
@@ -156,6 +159,7 @@ public class AppSettingStoreRealm implements AppSettingStore {
   private static final String CURRENT_USER_ID = "currentUserId";
   private static final String ACCESS_TOKEN_PREFIX = "accessToken_";
   private static final String TOKEN_SECRET_PREFIX = "tokenSecret_";
+  static final String USER_DIR_PREFIX = "user_";
 
   @Override
   public void storeAccessToken(AccessToken token) {
@@ -163,6 +167,9 @@ public class AppSettingStoreRealm implements AppSettingStore {
     final Set<String> authenticatedUsers
         = prefs.getStringSet(AUTHENTICATED_USERS, new HashSet<>());
     authenticatedUsers.add(Long.toString(userId));
+
+    final File dir = new File(filesDir, USER_DIR_PREFIX + userId);
+    dir.mkdir();
 
     prefs.edit()
         .putStringSet(AUTHENTICATED_USERS, authenticatedUsers)
@@ -188,6 +195,11 @@ public class AppSettingStoreRealm implements AppSettingStore {
   @Override
   public long getCurrentUserId() {
     return prefs.getLong(CURRENT_USER_ID, -1);
+  }
+
+  @Override
+  public File getCurrentUserDir() {
+    return new File(filesDir, USER_DIR_PREFIX + getCurrentUserId());
   }
 
   @Override

--- a/app/src/main/java/com/freshdigitable/udonroad/module/realm/AppSettingStoreRealm.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/module/realm/AppSettingStoreRealm.java
@@ -24,6 +24,7 @@ import com.freshdigitable.udonroad.datastore.AppSettingStore;
 import java.io.File;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
@@ -101,6 +102,12 @@ public class AppSettingStoreRealm implements AppSettingStore {
         user.merge(authenticatedUser, r);
       }
     });
+  }
+
+  @Override
+  public List<? extends User> getAllAuthenticatedUsers() {
+    return realm.where(UserRealm.class)
+        .findAll();
   }
 
   @Override

--- a/app/src/main/java/com/freshdigitable/udonroad/module/realm/AppSettingStoreRealm.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/module/realm/AppSettingStoreRealm.java
@@ -210,6 +210,14 @@ public class AppSettingStoreRealm implements AppSettingStore {
   }
 
   @Override
+  public String getCurrentUserScreenName() {
+    final UserRealm user = realm.where(UserRealm.class)
+        .equalTo("id", getCurrentUserId())
+        .findFirst();
+    return user.getScreenName();
+  }
+
+  @Override
   public void setCurrentUserId(long userId) {
     if (!isAuthenticatedUser(userId)) {
       throw new IllegalArgumentException("unregistered userId: " + userId);

--- a/app/src/main/java/com/freshdigitable/udonroad/module/realm/AppSettingStoreRealm.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/module/realm/AppSettingStoreRealm.java
@@ -175,9 +175,6 @@ public class AppSettingStoreRealm implements AppSettingStore {
         = prefs.getStringSet(AUTHENTICATED_USERS, new HashSet<>());
     authenticatedUsers.add(Long.toString(userId));
 
-    final File dir = new File(filesDir, USER_DIR_PREFIX + userId);
-    dir.mkdir();
-
     prefs.edit()
         .putStringSet(AUTHENTICATED_USERS, authenticatedUsers)
         .putString(ACCESS_TOKEN_PREFIX + userId, token.getToken())
@@ -207,14 +204,6 @@ public class AppSettingStoreRealm implements AppSettingStore {
   @Override
   public File getCurrentUserDir() {
     return new File(filesDir, USER_DIR_PREFIX + getCurrentUserId());
-  }
-
-  @Override
-  public String getCurrentUserScreenName() {
-    final UserRealm user = realm.where(UserRealm.class)
-        .equalTo("id", getCurrentUserId())
-        .findFirst();
-    return user.getScreenName();
   }
 
   @Override

--- a/app/src/main/java/com/freshdigitable/udonroad/module/realm/ConfigStoreRealm.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/module/realm/ConfigStoreRealm.java
@@ -20,6 +20,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 import com.freshdigitable.udonroad.StoreType;
+import com.freshdigitable.udonroad.datastore.AppSettingStore;
 import com.freshdigitable.udonroad.datastore.ConfigStore;
 import com.freshdigitable.udonroad.datastore.StatusReaction;
 
@@ -52,18 +53,23 @@ public class ConfigStoreRealm implements ConfigStore {
   @SuppressWarnings("unused")
   private static final String TAG = ConfigStoreRealm.class.getSimpleName();
   private Realm configStore;
-  private final RealmConfiguration config;
+  private RealmConfiguration config;
+  private final AppSettingStore appSettingStore;
 
-  public ConfigStoreRealm() {
-    config = new RealmConfiguration.Builder()
-        .name(StoreType.CONFIG.storeName)
-        .deleteRealmIfMigrationNeeded()
-        .build();
+  public ConfigStoreRealm(AppSettingStore appSettingStore) {
+    this.appSettingStore = appSettingStore;
   }
 
   @Override
   public void open() {
+    appSettingStore.open();
+    config = new RealmConfiguration.Builder()
+        .directory(appSettingStore.getCurrentUserDir())
+        .name(StoreType.CONFIG.storeName)
+        .deleteRealmIfMigrationNeeded()
+        .build();
     configStore = Realm.getInstance(config);
+    appSettingStore.close();
   }
 
   @Override

--- a/app/src/main/java/com/freshdigitable/udonroad/module/realm/ConfigStoreRealm.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/module/realm/ConfigStoreRealm.java
@@ -18,6 +18,7 @@ package com.freshdigitable.udonroad.module.realm;
 
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.util.Log;
 
 import com.freshdigitable.udonroad.StoreType;
 import com.freshdigitable.udonroad.datastore.AppSettingStore;
@@ -70,10 +71,12 @@ public class ConfigStoreRealm implements ConfigStore {
         .build();
     configStore = Realm.getInstance(config);
     appSettingStore.close();
+    Log.d(TAG, "open: " + config.getRealmDirectory());
   }
 
   @Override
   public void close() {
+    Log.d(TAG, "close: " + config.getRealmDirectory());
     configStore.close();
   }
 
@@ -177,8 +180,7 @@ public class ConfigStoreRealm implements ConfigStore {
   @NonNull
   @Override
   public Observable<? extends StatusReaction> observeById(long id) {
-    final StatusReactionRealm statusReaction = find(id);
-    return observeById(statusReaction);
+    return CacheUtil.observeById(configStore, id, StatusReactionRealm.class);
   }
 
   @NonNull

--- a/app/src/main/java/com/freshdigitable/udonroad/module/realm/ListsSortedCacheRealm.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/module/realm/ListsSortedCacheRealm.java
@@ -18,14 +18,13 @@ package com.freshdigitable.udonroad.module.realm;
 
 import android.support.annotation.NonNull;
 
+import com.freshdigitable.udonroad.datastore.AppSettingStore;
 import com.freshdigitable.udonroad.datastore.SortedCache;
 import com.freshdigitable.udonroad.datastore.TypedCache;
 import com.freshdigitable.udonroad.datastore.UpdateEvent;
 import com.freshdigitable.udonroad.datastore.UpdateEvent.EventType;
 import com.freshdigitable.udonroad.datastore.UpdateSubject;
 import com.freshdigitable.udonroad.datastore.UpdateSubjectFactory;
-
-import javax.inject.Inject;
 
 import io.reactivex.Flowable;
 import io.reactivex.Observable;
@@ -39,18 +38,18 @@ import twitter4j.UserList;
  * Created by akihit on 2017/08/17.
  */
 
-public class ListsSortedCache implements SortedCache<UserList> {
+public class ListsSortedCacheRealm implements SortedCache<UserList> {
   private final TypedCache<User> pool;
   private final NamingBaseCacheRealm sortedCache;
   private RealmResults<UserListRealm> userLists;
   private final UpdateSubjectFactory factory;
   private UpdateSubject updateSubject;
 
-  @Inject
-  public ListsSortedCache(UpdateSubjectFactory factory, TypedCache<User> pool) {
+  public ListsSortedCacheRealm(
+      UpdateSubjectFactory factory, TypedCache<User> pool, AppSettingStore appSettingStore) {
     this.factory = factory;
     this.pool = pool;
-    sortedCache = new NamingBaseCacheRealm();
+    sortedCache = new NamingBaseCacheRealm(appSettingStore);
   }
 
 
@@ -67,7 +66,7 @@ public class ListsSortedCache implements SortedCache<UserList> {
   private final OrderedRealmCollectionChangeListener<RealmResults<UserListRealm>> realmChangeListener
       = new OrderedRealmCollectionChangeListener<RealmResults<UserListRealm>>() {
     @Override
-    public void onChange(RealmResults<UserListRealm> element, OrderedCollectionChangeSet changeSet) {
+    public void onChange(@NonNull RealmResults<UserListRealm> element, @NonNull OrderedCollectionChangeSet changeSet) {
       if (updateSubject.hasSubscribers()) {
         final OrderedCollectionChangeSet.Range[] insertions = changeSet.getInsertionRanges();
         for (OrderedCollectionChangeSet.Range i : insertions) {

--- a/app/src/main/java/com/freshdigitable/udonroad/module/realm/PoolRealm.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/module/realm/PoolRealm.java
@@ -19,6 +19,8 @@ package com.freshdigitable.udonroad.module.realm;
 import android.support.annotation.CallSuper;
 import android.util.Log;
 
+import com.freshdigitable.udonroad.StoreType;
+import com.freshdigitable.udonroad.datastore.AppSettingStore;
 import com.freshdigitable.udonroad.datastore.BaseCache;
 
 import io.reactivex.Completable;
@@ -35,18 +37,23 @@ import io.realm.RealmModel;
 final class PoolRealm implements BaseCache {
   private static final String TAG = PoolRealm.class.getSimpleName();
   private Realm cache;
-  private final RealmConfiguration config;
+  private RealmConfiguration config;
+  private final AppSettingStore appSettingStore;
 
-  PoolRealm() {
-    config = new RealmConfiguration.Builder()
-        .name("cache")
-        .deleteRealmIfMigrationNeeded()
-        .build();
+  PoolRealm(AppSettingStore appSettingStore) {
+    this.appSettingStore = appSettingStore;
   }
 
   @Override
   @CallSuper
   public void open() {
+    appSettingStore.open();
+    config = new RealmConfiguration.Builder()
+        .directory(appSettingStore.getCurrentUserDir())
+        .name(StoreType.POOL.storeName)
+        .deleteRealmIfMigrationNeeded()
+        .build();
+    appSettingStore.close();
     Log.d(TAG, "open: " + config.getRealmFileName());
     cache = Realm.getInstance(config);
   }

--- a/app/src/main/java/com/freshdigitable/udonroad/module/realm/RealmObjectObservable.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/module/realm/RealmObjectObservable.java
@@ -31,7 +31,7 @@ import io.realm.RealmObject;
 class RealmObjectObservable<T extends RealmModel> extends Observable<T> {
   static <T extends RealmModel> Observable<T> create(T elem) {
     if (elem == null || !RealmObject.isValid(elem)) {
-      throw new IllegalStateException();
+      throw new IllegalStateException("unobservable element: " + elem);
     }
     return new RealmObjectObservable<>(elem);
   }

--- a/app/src/main/java/com/freshdigitable/udonroad/module/realm/StatusCacheRealm.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/module/realm/StatusCacheRealm.java
@@ -273,7 +273,7 @@ public class StatusCacheRealm implements TypedCache<Status>, MediaCache {
   @Override
   public Observable<? extends Status> observeById(Status status) {
     return status != null && status instanceof StatusRealm ?
-        StatusChangeObservable.create((StatusRealm) status)
+        StatusChangeObservable.create((StatusRealm) status, configStore)
             .filter(s -> RealmObject.isValid(s))
             .map(s -> {
               final Status quotedStatus = s.getQuotedStatus();
@@ -311,22 +311,25 @@ public class StatusCacheRealm implements TypedCache<Status>, MediaCache {
   }
 
   private static class StatusChangeObservable extends Observable<StatusRealm> {
-    static StatusChangeObservable create(@NonNull StatusRealm statusRealm) {
+    static StatusChangeObservable create(@NonNull StatusRealm statusRealm, ConfigStore configStore) {
       if (!statusRealm.isManaged()) {
         throw new IllegalStateException("status is not managed...");
       }
-      return new StatusChangeObservable(statusRealm);
+      return new StatusChangeObservable(statusRealm, configStore);
     }
 
     private final StatusRealm statusRealm;
     private final CompositeDisposable disposables = new CompositeDisposable();
     private final Collection<Observable<? extends RealmModel>> observables = new ArrayList<>();
 
-    private StatusChangeObservable(StatusRealm statusRealm) {
+    private StatusChangeObservable(StatusRealm statusRealm, ConfigStore configStore) {
       this.statusRealm = statusRealm;
       final StatusRealm bindingStatus = getBindingStatus(statusRealm);
       observables.add(observeStatus(bindingStatus));
-      observables.add(ConfigStoreRealm.observe((StatusReactionRealm) bindingStatus.getStatusReaction()));
+      final Observable<? extends RealmModel> reactionObservable = bindingStatus.getStatusReaction() != null ?
+          ConfigStoreRealm.observe((StatusReactionRealm) bindingStatus.getStatusReaction())
+          : configStore.observeById(bindingStatus.getId()).cast(StatusReactionRealm.class);
+      observables.add(reactionObservable);
       final Status quotedStatus = bindingStatus.getQuotedStatus();
       if (quotedStatus != null) {
         final StatusRealm qs = (StatusRealm) quotedStatus;

--- a/app/src/main/java/com/freshdigitable/udonroad/module/realm/StatusCacheRealm.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/module/realm/StatusCacheRealm.java
@@ -19,6 +19,7 @@ package com.freshdigitable.udonroad.module.realm;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
+import com.freshdigitable.udonroad.datastore.AppSettingStore;
 import com.freshdigitable.udonroad.datastore.ConfigStore;
 import com.freshdigitable.udonroad.datastore.MediaCache;
 import com.freshdigitable.udonroad.datastore.PerspectivalStatus;
@@ -60,9 +61,9 @@ public class StatusCacheRealm implements TypedCache<Status>, MediaCache {
   private final ConfigStore configStore;
   private UserCacheRealm userTypedCache;
 
-  public StatusCacheRealm(ConfigStore configStore) {
+  public StatusCacheRealm(ConfigStore configStore, AppSettingStore appSetting) {
     this.configStore = configStore;
-    this.pool = new PoolRealm();
+    this.pool = new PoolRealm(appSetting);
   }
 
   @Override

--- a/app/src/main/java/com/freshdigitable/udonroad/module/realm/TimelineStoreRealm.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/module/realm/TimelineStoreRealm.java
@@ -18,6 +18,7 @@ package com.freshdigitable.udonroad.module.realm;
 
 import android.support.annotation.NonNull;
 
+import com.freshdigitable.udonroad.datastore.AppSettingStore;
 import com.freshdigitable.udonroad.datastore.SortedCache;
 import com.freshdigitable.udonroad.datastore.TypedCache;
 import com.freshdigitable.udonroad.datastore.UpdateEvent;
@@ -50,7 +51,7 @@ public class TimelineStoreRealm implements SortedCache<Status> {
   private final OrderedRealmCollectionChangeListener<RealmResults<StatusIDs>> addChangeListener
       = new OrderedRealmCollectionChangeListener<RealmResults<StatusIDs>>() {
     @Override
-    public void onChange(RealmResults<StatusIDs> elem, OrderedCollectionChangeSet changeSet) {
+    public void onChange(@NonNull RealmResults<StatusIDs> elem, @NonNull OrderedCollectionChangeSet changeSet) {
       setItemCount(elem.size());
       if (updateSubject.hasSubscribers()) {
         for (OrderedCollectionChangeSet.Range range : changeSet.getInsertionRanges()) {
@@ -69,10 +70,10 @@ public class TimelineStoreRealm implements SortedCache<Status> {
   private final NamingBaseCacheRealm sortedCache;
 
   public TimelineStoreRealm(UpdateSubjectFactory factory,
-                            TypedCache<Status> statusCacheRealm) {
+                            TypedCache<Status> statusCacheRealm, AppSettingStore appSetting) {
     this.factory = factory;
     this.pool = statusCacheRealm;
-    sortedCache = new NamingBaseCacheRealm();
+    sortedCache = new NamingBaseCacheRealm(appSetting);
   }
 
   @Override

--- a/app/src/main/java/com/freshdigitable/udonroad/module/realm/UserCacheRealm.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/module/realm/UserCacheRealm.java
@@ -19,6 +19,7 @@ package com.freshdigitable.udonroad.module.realm;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
+import com.freshdigitable.udonroad.datastore.AppSettingStore;
 import com.freshdigitable.udonroad.datastore.TypedCache;
 
 import java.util.ArrayList;
@@ -39,8 +40,8 @@ import twitter4j.User;
 public class UserCacheRealm implements TypedCache<User> {
   private final PoolRealm pool;
 
-  public UserCacheRealm() {
-    this(new PoolRealm());
+  public UserCacheRealm(AppSettingStore appSettingStore) {
+    this(new PoolRealm(appSettingStore));
   }
 
   UserCacheRealm(PoolRealm pool) {

--- a/app/src/main/java/com/freshdigitable/udonroad/module/realm/UserSortedCacheRealm.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/module/realm/UserSortedCacheRealm.java
@@ -18,6 +18,7 @@ package com.freshdigitable.udonroad.module.realm;
 
 import android.support.annotation.NonNull;
 
+import com.freshdigitable.udonroad.datastore.AppSettingStore;
 import com.freshdigitable.udonroad.datastore.SortedCache;
 import com.freshdigitable.udonroad.datastore.TypedCache;
 import com.freshdigitable.udonroad.datastore.UpdateEvent;
@@ -44,10 +45,11 @@ public class UserSortedCacheRealm implements SortedCache<User> {
   private final UpdateSubjectFactory factory;
   private UpdateSubject updateSubject;
 
-  public UserSortedCacheRealm(UpdateSubjectFactory factory, TypedCache<User> userCacheRealm) {
+  public UserSortedCacheRealm(
+      UpdateSubjectFactory factory, TypedCache<User> userCacheRealm, AppSettingStore appSetting) {
     this.factory = factory;
     this.pool = userCacheRealm;
-    this.sortedCache = new NamingBaseCacheRealm();
+    this.sortedCache = new NamingBaseCacheRealm(appSetting);
   }
 
   @Override
@@ -123,7 +125,7 @@ public class UserSortedCacheRealm implements SortedCache<User> {
   private final OrderedRealmCollectionChangeListener<RealmResults<ListedUserIDs>> realmChangeListener
       = new OrderedRealmCollectionChangeListener<RealmResults<ListedUserIDs>>() {
     @Override
-    public void onChange(RealmResults<ListedUserIDs> element, OrderedCollectionChangeSet changeSet) {
+    public void onChange(@NonNull RealmResults<ListedUserIDs> element, @NonNull OrderedCollectionChangeSet changeSet) {
       if (updateSubject.hasSubscribers()) {
         final OrderedCollectionChangeSet.Range[] insertions = changeSet.getInsertionRanges();
         for (OrderedCollectionChangeSet.Range i : insertions) {

--- a/app/src/main/java/com/freshdigitable/udonroad/module/realm/WritableListsSortedCache.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/module/realm/WritableListsSortedCache.java
@@ -16,6 +16,7 @@
 
 package com.freshdigitable.udonroad.module.realm;
 
+import com.freshdigitable.udonroad.datastore.AppSettingStore;
 import com.freshdigitable.udonroad.datastore.TypedCache;
 import com.freshdigitable.udonroad.datastore.WritableSortedCache;
 
@@ -38,9 +39,9 @@ public class WritableListsSortedCache implements WritableSortedCache<UserList> {
   private final TypedCache<User> pool;
   private final NamingBaseCacheRealm sortedCache;
 
-  public WritableListsSortedCache(TypedCache<User> pool) {
+  public WritableListsSortedCache(TypedCache<User> pool, AppSettingStore appSetting) {
     this.pool = pool;
-    sortedCache = new NamingBaseCacheRealm();
+    sortedCache = new NamingBaseCacheRealm(appSetting);
   }
 
   @Override

--- a/app/src/main/java/com/freshdigitable/udonroad/module/realm/WritableTimelineRealm.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/module/realm/WritableTimelineRealm.java
@@ -18,6 +18,7 @@ package com.freshdigitable.udonroad.module.realm;
 
 import android.util.Log;
 
+import com.freshdigitable.udonroad.datastore.AppSettingStore;
 import com.freshdigitable.udonroad.datastore.ConfigStore;
 import com.freshdigitable.udonroad.datastore.TypedCache;
 import com.freshdigitable.udonroad.datastore.WritableSortedCache;
@@ -45,10 +46,11 @@ public class WritableTimelineRealm implements WritableSortedCache<Status> {
   private final ConfigStore configStore;
   private final NamingBaseCacheRealm sortedCache;
 
-  public WritableTimelineRealm(TypedCache<Status> statusCacheRealm, ConfigStore configStore) {
+  public WritableTimelineRealm(
+      TypedCache<Status> statusCacheRealm, ConfigStore configStore, AppSettingStore appSetting) {
     this.pool = statusCacheRealm;
     this.configStore = configStore;
-    sortedCache = new NamingBaseCacheRealm();
+    sortedCache = new NamingBaseCacheRealm(appSetting);
   }
 
   @Override

--- a/app/src/main/java/com/freshdigitable/udonroad/module/realm/WritableUserSortedCacheRealm.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/module/realm/WritableUserSortedCacheRealm.java
@@ -16,6 +16,7 @@
 
 package com.freshdigitable.udonroad.module.realm;
 
+import com.freshdigitable.udonroad.datastore.AppSettingStore;
 import com.freshdigitable.udonroad.datastore.TypedCache;
 import com.freshdigitable.udonroad.datastore.WritableSortedCache;
 
@@ -37,8 +38,8 @@ public class WritableUserSortedCacheRealm implements WritableSortedCache<User> {
   private final NamingBaseCacheRealm sortedCache;
   private final TypedCache<User> pool;
 
-  public WritableUserSortedCacheRealm(TypedCache<User> pool) {
-    sortedCache = new NamingBaseCacheRealm();
+  public WritableUserSortedCacheRealm(TypedCache<User> pool, AppSettingStore appSetting) {
+    sortedCache = new NamingBaseCacheRealm(appSetting);
     this.pool = pool;
   }
 

--- a/app/src/main/java/com/freshdigitable/udonroad/module/twitter/TwitterApi.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/module/twitter/TwitterApi.java
@@ -83,7 +83,7 @@ public class TwitterApi {
   }
 
   public Single<User> verifyCredentials() {
-    return observeThrowableFetch(() -> twitter.showUser(twitter.getId()));
+    return observeThrowableFetch(twitter::verifyCredentials);
   }
 
   public Single<TwitterAPIConfiguration> getTwitterAPIConfiguration() {

--- a/app/src/main/java/com/freshdigitable/udonroad/subscriber/AppSettingRequestWorker.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/subscriber/AppSettingRequestWorker.java
@@ -28,7 +28,6 @@ import javax.inject.Inject;
 
 import io.reactivex.functions.Consumer;
 import twitter4j.User;
-import twitter4j.auth.AccessToken;
 
 /**
  * Created by akihit on 2017/07/17.
@@ -54,8 +53,6 @@ public class AppSettingRequestWorker implements RequestWorker {
       return false;
     }
     appSettings.open();
-    final AccessToken accessToken = appSettings.getCurrentUserAccessToken();
-    twitterApi.setOAuthAccessToken(accessToken);
     if (!appSettings.getCurrentUserDir().exists()) {
       appSettings.getCurrentUserDir().mkdir();
     }

--- a/app/src/main/java/com/freshdigitable/udonroad/subscriber/AppSettingRequestWorker.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/subscriber/AppSettingRequestWorker.java
@@ -56,6 +56,9 @@ public class AppSettingRequestWorker implements RequestWorker {
     appSettings.open();
     final AccessToken accessToken = appSettings.getCurrentUserAccessToken();
     twitterApi.setOAuthAccessToken(accessToken);
+    if (!appSettings.getCurrentUserDir().exists()) {
+      appSettings.getCurrentUserDir().mkdir();
+    }
     final boolean twitterAPIConfigFetchable = appSettings.isTwitterAPIConfigFetchable();
     appSettings.close();
     if (twitterAPIConfigFetchable) {

--- a/app/src/main/java/com/freshdigitable/udonroad/subscriber/ConfigRequestWorker.java
+++ b/app/src/main/java/com/freshdigitable/udonroad/subscriber/ConfigRequestWorker.java
@@ -18,7 +18,6 @@ package com.freshdigitable.udonroad.subscriber;
 
 import android.support.annotation.NonNull;
 import android.support.annotation.StringRes;
-import android.util.Log;
 
 import com.freshdigitable.udonroad.R;
 import com.freshdigitable.udonroad.datastore.ConfigStore;
@@ -82,10 +81,7 @@ public class ConfigRequestWorker implements RequestWorker {
           cache.replaceIgnoringUsers(u);
           cache.close();
           emitter.onComplete();
-        }, th -> {
-          Log.e(TAG, "call: ", th);
-          emitter.onError(th);
-        });
+        }, emitter::onError);
   }
 
   public void fetchRelationship(long userId) {

--- a/app/src/main/res/drawable/ic_arrow_drop_down.xml
+++ b/app/src/main/res/drawable/ic_arrow_drop_down.xml
@@ -1,0 +1,25 @@
+<!--
+  ~ Copyright (c) 2017. Matsuda, Akihit (akihito104)
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="@color/text_primary_inverse"
+        android:pathData="M7,10l5,5 5,-5z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_arrow_drop_up.xml
+++ b/app/src/main/res/drawable/ic_arrow_drop_up.xml
@@ -1,0 +1,25 @@
+<!--
+  ~ Copyright (c) 2017. Matsuda, Akihit (akihito104)
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="@color/text_primary_inverse"
+        android:pathData="M7,14l5,-5 5,5z"/>
+</vector>

--- a/app/src/main/res/layout/nav_header.xml
+++ b/app/src/main/res/layout/nav_header.xml
@@ -45,7 +45,6 @@
             android:maxLines="2"
             android:textSize="@dimen/nav_drawer_header_text"
             android:textColor="@color/text_primary_inverse"
-            android:drawableEnd="@drawable/ic_arrow_drop_down"
             tools:text="name\n\@screen_name"
             />
     </LinearLayout>

--- a/app/src/main/res/layout/nav_header.xml
+++ b/app/src/main/res/layout/nav_header.xml
@@ -45,6 +45,7 @@
             android:maxLines="2"
             android:textSize="@dimen/nav_drawer_header_text"
             android:textColor="@color/text_primary_inverse"
+            android:drawableEnd="@drawable/ic_arrow_drop_down"
             tools:text="name\n\@screen_name"
             />
     </LinearLayout>

--- a/app/src/main/res/menu/nav_menu.xml
+++ b/app/src/main/res/menu/nav_menu.xml
@@ -17,6 +17,11 @@
 
 <menu xmlns:android="http://schemas.android.com/apk/res/android">
     <item
+        android:id="@+id/drawer_menu_add_account"
+        android:title="@string/drawer_menu_add_account"
+        android:visible="false"
+        />
+    <item
         android:id="@+id/drawer_menu_home"
         android:title="@string/drawer_menu_home"/>
     <item

--- a/app/src/main/res/menu/nav_menu.xml
+++ b/app/src/main/res/menu/nav_menu.xml
@@ -23,6 +23,7 @@
             android:id="@+id/drawer_menu_add_account"
             android:title="@string/drawer_menu_add_account"
             android:visible="false"
+            android:orderInCategory="1000"
             />
     </group>
     <group

--- a/app/src/main/res/menu/nav_menu.xml
+++ b/app/src/main/res/menu/nav_menu.xml
@@ -16,18 +16,26 @@
   -->
 
 <menu xmlns:android="http://schemas.android.com/apk/res/android">
-    <item
-        android:id="@+id/drawer_menu_add_account"
-        android:title="@string/drawer_menu_add_account"
-        android:visible="false"
-        />
-    <item
-        android:id="@+id/drawer_menu_home"
-        android:title="@string/drawer_menu_home"/>
-    <item
-        android:id="@+id/drawer_menu_lists"
-        android:title="@string/lists"/>
-    <item
-        android:id="@+id/drawer_menu_license"
-        android:title="@string/drawer_menu_license"/>
+    <group
+        android:id="@+id/drawer_menu_accounts"
+        >
+        <item
+            android:id="@+id/drawer_menu_add_account"
+            android:title="@string/drawer_menu_add_account"
+            android:visible="false"
+            />
+    </group>
+    <group
+        android:id="@+id/drawer_menu_default"
+        >
+        <item
+            android:id="@+id/drawer_menu_home"
+            android:title="@string/drawer_menu_home"/>
+        <item
+            android:id="@+id/drawer_menu_lists"
+            android:title="@string/lists"/>
+        <item
+            android:id="@+id/drawer_menu_license"
+            android:title="@string/drawer_menu_license"/>
+    </group>
 </menu>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -124,4 +124,5 @@
     <string name="oauth_explain">下のボタンからTwitterへログインし、\'aoeliyakei\'でツイートできるように権限を付与してください。そうすると数桁の数字(PINコード)が表示されるので、それをコピーしてこのアプリに戻ってきてください。</string>
     <string name="oauth_pin_direction">表示されたPINコードを入力して送信してください。</string>
     <string name="msg_oauth_user_icon">ユーザーの情報をみることができます</string>
+    <string name="drawer_menu_add_account">登録済みアカウントの追加…</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -125,4 +125,5 @@
     <string name="oauth_pin_direction">表示されたPINコードを入力して送信してください。</string>
     <string name="msg_oauth_user_icon">ユーザーの情報をみることができます</string>
     <string name="drawer_menu_add_account">登録済みアカウントの追加…</string>
+    <string name="title_add_account">登録済みアカウントの追加</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -105,6 +105,7 @@
     <string name="media_upload_delete">delete</string>
     <string name="drawer_menu_home">home</string>
     <string name="drawer_menu_license">OSS license</string>
+    <string name="drawer_menu_add_account">add registered account</string>
     <string name="lists">lists</string>
     <string name="title_owned_list">lists</string>
     <string name="oauth_hint_input_pin">input PIN code</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -100,6 +100,7 @@
     <string name="title_reply">reply</string>
     <string name="title_comment">comment</string>
     <string name="title_oauth">welcome</string>
+    <string name="title_add_account">add registered account</string>
 
     <string name="media_chooser_title">choose to upload…</string>
     <string name="media_upload_delete">delete</string>


### PR DESCRIPTION
- [x] Realmファイルのディレクトリ構成を変更する
- [x] NavigationDrawerのアカウント名をクリックしてメニューを切り替える
    - [x] メニューのモードによって矢印の向きを変える
    - [x] Lより前のバージョンでも表示できるようにする
- [x] 登録済みアカウントを追加できるようにする
- [x] 登録済みアカウントをクリックしてアカウントを切り替えられるようにする

refs: #253 