### PR TITLE
destroyFav/RTをするとクラッシュするバグの修正

### DIFF
--- a/app/src/androidTest/java/com/freshdigitable/udonroad/MockAppComponent.java
+++ b/app/src/androidTest/java/com/freshdigitable/udonroad/MockAppComponent.java
@@ -17,6 +17,7 @@
 package com.freshdigitable.udonroad;
 
 import com.freshdigitable.udonroad.datastore.AppSettingStoreTest;
+import com.freshdigitable.udonroad.datastore.StatusTypedCacheTest;
 import com.freshdigitable.udonroad.module.AppComponent;
 import com.freshdigitable.udonroad.module.DataStoreModule;
 import com.freshdigitable.udonroad.module.TwitterApiModule;
@@ -54,4 +55,6 @@ public interface MockAppComponent extends AppComponent {
   void inject(AppSettingStoreTest appSettingStoreTest);
 
   void inject(TweetInputActivityInstTest tweetInputActivityInstTest);
+
+  void inject(StatusTypedCacheTest statusTypedCacheTest);
 }

--- a/app/src/androidTest/java/com/freshdigitable/udonroad/StatusDetailInstTest.java
+++ b/app/src/androidTest/java/com/freshdigitable/udonroad/StatusDetailInstTest.java
@@ -119,6 +119,30 @@ public class StatusDetailInstTest extends TimelineInstTestBase {
   }
 
   @Test
+  public void destroyFavoSimpleStatusOnStatusDetail_and_backToMain() throws Exception {
+    setupCreateFavorite(3, 9);
+    setupDestroyFavorite(3, 8);
+
+    PerformUtil.selectItemView(simple);
+    PerformUtil.showDetail();
+    AssertionUtil.checkMainActivityTitle(R.string.title_detail);
+    onView(withId(R.id.timeline)).check(doesNotExist());
+    onView(withId(R.id.d_tweet)).check(matches(withText(simple.getText())));
+    onView(withId(R.id.iffabMenu_main_fav)).perform(click());
+    onView(withId(R.id.iffabMenu_main_fav)).check(matches(withDrawableState(android.R.attr.state_checked)));
+    checkRTCount(3);
+    checkFavCount(9);
+
+    onView(withId(R.id.iffabMenu_main_fav)).perform(click());
+    onView(withId(R.id.iffabMenu_main_fav)).check(matches(not(withDrawableState(android.R.attr.state_checked))));
+    checkRTCount(3);
+    checkFavCount(8);
+
+    Espresso.pressBack();
+    AssertionUtil.checkMainActivityTitle(R.string.title_home);
+  }
+
+  @Test
   public void showStatusDetailForSimpleStatus_then_clickUserIcon() {
     PerformUtil.selectItemView(simple);
     PerformUtil.showDetail();

--- a/app/src/androidTest/java/com/freshdigitable/udonroad/TimelineInstTestBase.java
+++ b/app/src/androidTest/java/com/freshdigitable/udonroad/TimelineInstTestBase.java
@@ -329,6 +329,17 @@ public abstract class TimelineInstTestBase {
     });
   }
 
+  protected void setupDestroyFavorite(final int rtCount, final int favCount) throws TwitterException {
+    when(twitter.destroyFavorite(anyLong())).thenAnswer(invocation -> {
+      final Long id = invocation.getArgument(0);
+      final Status status = findByStatusId(id);
+      when(status.getFavoriteCount()).thenReturn(favCount);
+      when(status.getRetweetCount()).thenReturn(rtCount);
+      when(status.isFavorited()).thenReturn(false);
+      return status;
+    });
+  }
+
   protected void setupRetweetStatus(final long rtStatusId, final int rtCount, final int favCount)
       throws TwitterException {
     when(twitter.retweetStatus(anyLong())).thenAnswer(invocation -> {

--- a/app/src/androidTest/java/com/freshdigitable/udonroad/datastore/StatusTypedCacheTest.java
+++ b/app/src/androidTest/java/com/freshdigitable/udonroad/datastore/StatusTypedCacheTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2018. Matsuda, Akihit (akihito104)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.freshdigitable.udonroad.datastore;
+
+import android.support.test.runner.AndroidJUnit4;
+
+import com.freshdigitable.udonroad.util.StorageUtil;
+import com.freshdigitable.udonroad.util.TestInjectionUtil;
+import com.freshdigitable.udonroad.util.TwitterResponseMock;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.inject.Inject;
+
+import twitter4j.Status;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Created by akihit on 2018/01/24.
+ */
+@RunWith(AndroidJUnit4.class)
+public class StatusTypedCacheTest {
+  @Inject
+  TypedCache<Status> sut;
+
+  @Before
+  public void setup() {
+    TestInjectionUtil.getComponent().inject(this);
+    StorageUtil.initStorage();
+    sut.open();
+  }
+
+  @After
+  public void tearDown() {
+    sut.close();
+  }
+
+  @Test
+  public void insertStatus_andThen_findSameOne() {
+    final Status target = TwitterResponseMock.createStatus(200);
+
+    sut.insert(target);
+
+    final Status actual = sut.find(200);
+    assertThat(actual, is(notNullValue()));
+    assertThat(actual.getId(), is(equalTo(target.getId())));
+    assertThat(actual.getUser(), is(notNullValue()));
+  }
+
+  @Test
+  public void upsertStatus_andThen_findSameOne() {
+    final Status target = TwitterResponseMock.createStatus(200);
+
+    sut.upsert(target);
+
+    final Status actual = sut.find(200);
+    assertThat(actual, is(notNullValue()));
+    assertThat(actual.getId(), is(equalTo(target.getId())));
+    assertThat(actual.getUser(), is(notNullValue()));
+  }
+}


### PR DESCRIPTION
refs: #320 
- [x] favのときのテストを追加
- RTのときのテストを追加 -> #309 でやる
- [x] TypedCache<Status>.insert()の処理が正しくないのを修正
